### PR TITLE
Add default-level config

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -57,6 +57,7 @@ Configuration is read from the following (in precedence order)
 | `pre-release-hook` | \-          | list of arguments | Provide a command to run before `cargo-release` commits version change. If the return code of hook command is greater than 0, the release process will be aborted. |
 | `enable-features` | `--features` | list of names | Provide a set of feature flags that should be passed to `cargo publish` (requires rust 1.33+) |
 | `all-features` | `--all-features` | bool  | Signal to `cargo publish`, that all features should be used (requires rust 1.33+) |
+| `default-level` | \- | string | Default bump level |
 
 ### Pre-release Replacements
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::FatalError;
+use crate::version::BumpLevel;
 
 pub trait ConfigSource {
     fn sign_commit(&self) -> Option<bool> {
@@ -87,6 +88,10 @@ pub trait ConfigSource {
     fn dependent_version(&self) -> Option<DependentVersion> {
         None
     }
+
+    fn default_level(&self) -> Option<BumpLevel> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -113,6 +118,7 @@ pub struct Config {
     pub enable_features: Option<Vec<String>>,
     pub enable_all_features: Option<bool>,
     pub dependent_version: Option<DependentVersion>,
+    pub default_level: Option<BumpLevel>,
 }
 
 impl Config {
@@ -176,6 +182,9 @@ impl Config {
         }
         if let Some(dependent_version) = source.dependent_version() {
             self.dependent_version = Some(dependent_version);
+        }
+        if let Some(default_level) = source.default_level() {
+            self.default_level = Some(default_level);
         }
     }
 
@@ -288,6 +297,10 @@ impl Config {
     pub fn dependent_version(&self) -> DependentVersion {
         self.dependent_version.unwrap_or_default()
     }
+
+    pub fn default_level(&self) -> BumpLevel {
+        self.default_level.unwrap_or_default()
+    }
 }
 
 impl ConfigSource for Config {
@@ -369,6 +382,10 @@ impl ConfigSource for Config {
 
     fn dependent_version(&self) -> Option<DependentVersion> {
         self.dependent_version
+    }
+
+    fn default_level(&self) -> Option<BumpLevel> {
+        self.default_level
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,4 +1,5 @@
 use semver::{Identifier, Version};
+use serde::{Deserialize, Serialize};
 
 use crate::error::FatalError;
 
@@ -7,7 +8,8 @@ static VERSION_BETA: &'static str = "beta";
 static VERSION_RC: &'static str = "rc";
 
 arg_enum! {
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+    #[serde(rename_all = "kebab-case")]
     pub enum BumpLevel {
         Major,
         Minor,
@@ -16,6 +18,12 @@ arg_enum! {
         Beta,
         Alpha,
         Release,
+    }
+}
+
+impl Default for BumpLevel {
+    fn default() -> Self {
+        BumpLevel::Release
     }
 }
 


### PR DESCRIPTION
This PR add `default-level` to config file.

In https://github.com/sunng87/cargo-release/issues/77, workspace with pre-release does not seem to be supported.
So I want to use `cargo release patch` with `no-dev-version` option.
If there is `default-level` configuration, I can `cargo release` simply.