### PR TITLE
Skip git push if remote is not configured [#155]

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -84,6 +84,17 @@ pub fn push_tag(dir: &Path, remote: &str, tag: &str, dry_run: bool) -> Result<bo
     call_on_path(vec!["git", "push", remote, tag], dir, dry_run)
 }
 
+pub fn check_remote(dir: &Path, remote: &str) -> bool {
+    Command::new("git")
+        .arg("remote")
+        .arg("get-url")
+        .arg(remote)
+        .current_dir(dir)
+        .output()
+        .map(|r| r.status.success())
+        .unwrap_or(false)
+}
+
 pub fn top_level(dir: &Path) -> Result<PathBuf, FatalError> {
     let output = Command::new("git")
         .arg("rev-parse")

--- a/src/main.rs
+++ b/src/main.rs
@@ -469,11 +469,18 @@ fn release_package(
     if !pkg.config.disable_push() {
         log::info!("Pushing to git remote");
         let git_remote = pkg.config.push_remote();
-        if !git::push(cwd, git_remote, dry_run)? {
-            return Ok(106);
-        }
-        if !pkg.config.disable_tag() && !git::push_tag(cwd, git_remote, &tag_name, dry_run)? {
-            return Ok(106);
+        if git::check_remote(cwd, git_remote) {
+            if !git::push(cwd, git_remote, dry_run)? {
+                return Ok(106);
+            }
+            if !pkg.config.disable_tag() && !git::push_tag(cwd, git_remote, &tag_name, dry_run)? {
+                return Ok(106);
+            }
+        } else {
+            log::info!(
+                "push_remote: {} is not configured for git, skip git push",
+                git_remote
+            );
         }
     }
 


### PR DESCRIPTION
Added a check before running `git push`. If the remote is not configured, print info message and skip the push.

Fixes #155 