### PR TITLE
(feat) New flag --exclude-unchanged

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -11,6 +11,7 @@
 | `<LEVEL>`       | string | Bump specified version field. |
 | `--metadata`    | string | Populate the metadata field in the version. |
 | `--token`       | string | Token to use when running `cargo publish` |
+| `--exclude-unchanged` | bool | Only act on (transitive dependencies of) packages that have changed since the previous release |
 
 ### Bump level
 


### PR DESCRIPTION
In order to publish just those crates in a workspace that have changed (plus their transitive dependencies), I've added an `--exclude-unchanged` flag. It further filters the `pkgs` selection resulting from consulting the workspace and the `--package` and `--exclude` flags.