### PR TITLE
Add {{version_without_metadata}}

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -97,6 +97,7 @@ The following placeholders in configuration values will be be replaced with the 
 
 * `{{prev_version}}`: The version before `cargo-release` was executed (before any version bump).
 * `{{version}}`: The current (bumped) crate version.
+* `{{version_without_metadata}}`: The current (bumped) crate version, but with the (optional) metadata stripped. Useful for cargo dependencies, which can't contain metadata.
 * `{{next_version}}` (only valid for `post-release-{commit-message,replacements}`): The crate version for starting development.
 * `{{crate_name}}`: The name of the current crate in `Cargo.toml`.
 * `{{date}}`: The current date in `%Y-%m-%d` format.

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,11 +268,14 @@ fn release_packages<'m>(
                 cargo::update_lock(pkg.manifest_path)?;
             }
 
+            let without_metadata = version.without_metadata();
+
             if !pkg.config.pre_release_replacements().is_empty() {
                 // try replacing text in configured files
                 let template = Template {
                     prev_version: Some(&pkg.prev_version.version_string),
                     version: Some(new_version_string),
+                    version_without_metadata: Some(&without_metadata),
                     crate_name: Some(crate_name),
                     date: Some(NOW.as_str()),
                     tag_name: pkg.tag.as_deref(),

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -10,6 +10,7 @@ use crate::error::FatalError;
 pub struct Template<'a> {
     pub prev_version: Option<&'a str>,
     pub version: Option<&'a str>,
+    pub version_without_metadata: Option<&'a str>,
     pub crate_name: Option<&'a str>,
     pub date: Option<&'a str>,
 
@@ -26,6 +27,9 @@ impl<'a> Template<'a> {
         }
         if let Some(version) = self.version {
             s = s.replace("{{version}}", version);
+        }
+        if let Some(version_without_metadata) = self.version_without_metadata {
+            s = s.replace("{{version_without_metadata}}", version_without_metadata);
         }
         if let Some(crate_name) = self.crate_name {
             s = s.replace("{{crate_name}}", crate_name);

--- a/src/version.rs
+++ b/src/version.rs
@@ -89,6 +89,12 @@ impl Version {
     pub fn is_prerelease(&self) -> bool {
         self.version.is_prerelease()
     }
+
+    pub fn without_metadata(&self) -> String {
+        let mut stripped_version = self.version.clone();
+        stripped_version.build = semver::BuildMetadata::EMPTY.clone();
+        stripped_version.to_string()
+    }
 }
 
 arg_enum! {
@@ -543,6 +549,15 @@ mod test {
             assert_req_bump("1.1.0", "=1.0.0", "=1.1.0");
             assert_req_bump("1.1.1", "=1.0.0", "=1.1.1");
             assert_req_bump("2.0.0", "=1.0.0", "=2.0.0");
+        }
+
+        #[test]
+        fn metadata_strip() {
+            let version = Version {
+                version: semver::Version::parse("1.0.0-rc1+metadata.0.0").unwrap(),
+                version_string: "1.0.0-rc1+metadata.0.0".to_string(),
+            };
+            assert_eq!("1.0.0-rc1", version.without_metadata().to_string());
         }
     }
 }


### PR DESCRIPTION
Fixes #308

Chose to leave `{{version}}` be what it always was to maintain backcompat. Added an additional `{{version_without_metadata}}` that can be used on crates that have version numbers with metadata (for example to update their cargo dependencies).