### PR TITLE
fix: next_version not rendered in post commit message

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -2,6 +2,6 @@ pre-release-commit-message = "chore: Release"
 tag-message = "{{tag_name}}"
 tag-name = "{{prefix}}v{{version}}"
 pre-release-hook = ["./hook.sh", "一", "два", "Three", "4"]
-consolidate-commits = true
+consolidate-commits = false
 consolidate-pushes = true
 allow-branch = ["master"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -463,12 +463,13 @@ fn release_packages<'m>(
                     dry_run,
                 )?;
             }
-            let commit_msg = template.render(pkg.config.post_release_commit_message());
 
             if ws_config.consolidate_commits() {
                 shared_commit = true;
             } else {
                 let sign = pkg.config.sign_commit();
+
+                let commit_msg = template.render(pkg.config.post_release_commit_message());
                 if !git::commit_all(cwd, &commit_msg, sign, dry_run)? {
                     return Ok(105);
                 }


### PR DESCRIPTION
By turning off consolidate-commits for this project. A better approach
is to provide additional tempalte variables to consolidate-commits
template if current project is not a workspace, or has a fixed release
version.