### PR TITLE
fix(config): Don't crash on `publish = false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Crash when setting `publish = false` in `Cargo.toml` **and**` in a config file / commandline
+
 ## [0.18.1] - 2021-10-09
 
 ### Fixed

--- a/src/main.rs
+++ b/src/main.rs
@@ -676,7 +676,8 @@ impl<'m> PackageRelease<'m> {
                 .and_then(|f| f.as_bool())
                 .unwrap_or(true)
             {
-                release_config.disable_publish = Some(true);
+                release_config.publish = Some(false);
+                release_config.disable_publish = None;
             }
 
             release_config


### PR DESCRIPTION
When switching our config around, the code assumes that only the
positive or negative version of a field is set.  We then try to cover
all of the config merges that cause such a conflict.  We missed the
manual override of the `publish` field, taken from `Cargo.toml`.

Fixes #343