### PR TITLE
Update to crates-index@0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,12 +200,11 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad4af5c8dd9940a497ef4473e6e558b660a4a1b6e5ce2cb9d85454e2aaaf947"
+checksum = "87c1041763543466e437ad3212f1dbfd73c0ae4f7323e44ff584c5273d1b39c8"
 dependencies = [
  "git2",
- "glob",
  "hex",
  "home",
  "memchr",
@@ -316,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.22"
+version = "0.13.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1cbbfc9a1996c6af82c2b4caf828d2c653af4fcdbb0e5674cc966eee5a4197"
+checksum = "2a8057932925d3a9d9e4434ea016570d37420ddb1ceed45a174d577f24ed6700"
 dependencies = [
  "bitflags",
  "libc",
@@ -328,12 +327,6 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
@@ -493,9 +486,9 @@ checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.23+1.2.0"
+version = "0.12.24+1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29730a445bae719db3107078b46808cc45a5b7a6bae3f31272923af969453356"
+checksum = "ddbd6021eef06fb289a8f54b3c2acfdd85ff2a585dfbb24b8576325373d2152c"
 dependencies = [
  "cc",
  "libc",
@@ -841,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ pre-release-replacements = [
 
 [dependencies]
 cargo_metadata = "0.14"
-crates-index = "0.17"
+crates-index = "0.18"
 toml_edit = { version = "0.5.0", features = ["easy"] }
 serde = { version = "1.0", features = ["derive"] }
 semver = "1.0"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -111,11 +111,10 @@ pub fn wait_for_publish(
     if !dry_run {
         let now = std::time::Instant::now();
         let sleep_time = std::time::Duration::from_secs(1);
-        let index = crates_index::BareIndex::new_cargo_default();
-        let mut index = index.open_or_clone()?;
+        let mut index = crates_index::Index::new_cargo_default()?;
         let mut logged = false;
         loop {
-            if let Err(e) = index.retrieve() {
+            if let Err(e) = index.update() {
                 log::debug!("Crate index update failed with {}", e);
             }
             let crate_data = index.crate_(name);


### PR DESCRIPTION
Updates crates-index and its usage.

I thought this was related to https://github.com/crate-ci/cargo-release/issues/339 (it is not really).

A dependency bump is probably ok here though. Replaced `.retrieve` with `.update` as retrieve seems to be deprecated.