### PR TITLE
fix: Vendor libgit2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cargo_metadata = "0.14"
 crates-index = "0.18"
 # Enabling the feature for `crates-index`
 git2 = { version = "0.13", features = ["vendored-libgit2"] }
-toml_edit = { version = "0.5.0", features = ["easy"] }
+toml_edit = { version = "0.6.0", features = ["easy"] }
 serde = { version = "1.0", features = ["derive"] }
 semver = "1.0"
 quick-error = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ pre-release-replacements = [
 [dependencies]
 cargo_metadata = "0.14"
 crates-index = "0.18"
+# Enabling the feature for `crates-index`
+git2 = { version = "0.13", features = ["vendored-libgit2"] }
 toml_edit = { version = "0.5.0", features = ["easy"] }
 serde = { version = "1.0", features = ["derive"] }
 semver = "1.0"


### PR DESCRIPTION
I believe this will fix #339.  We've also seen similar problems with not
vendoring with cargo-edit.

Fixes #339