### PR TITLE
Support for tab completion

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -15,6 +15,7 @@ pub enum Command {
         setting = structopt::clap::AppSettings::DontCollapseArgsInUsage
     )]
     Release(ReleaseOpt),
+    Completions(CompletionsOpt),
 }
 
 #[derive(Debug, StructOpt)]
@@ -221,4 +222,10 @@ fn resolve_bool_arg(yes: bool, no: bool) -> Option<bool> {
         (false, false) => None,
         (_, _) => unreachable!("StructOpt should make this impossible"),
     }
+}
+
+#[derive(StructOpt, Debug, Clone)]
+pub struct CompletionsOpt {
+    #[structopt(long, short = "s", possible_values = &clap::Shell::variants(), case_insensitive = true)]
+    pub shell: clap::Shell,
 }


### PR DESCRIPTION
First of all, thanks for creating `cargo-release`! I use it in virtually all of my Rust projects, and it's an absolute pleasure to use.

This PR introduces self-generating tab completion (aka "shell completion" in some shells) to `cargo-release`. It uses `clap`'s built-in tab completion generation, by way of `structop`. Every shell completion dialect supported by `clap` is transparently supported by `cargo-release`.

By way of example, this command can be used to load shell completions for `cargo-release` into a `bash` session:

```bash
eval "$(cargo-release completions --shell=bash)"
```

This is similar but not identical to the CLI provided by tools like `rustup`, which exposes `rustup completions [tool] [shell]` to provide completions.

Let me know what you think! I'm happy to tweak the behavior, as desired. 