### PR TITLE
fix: Don't fail due to logging messages 

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -17,7 +17,7 @@ pub enum Command {
     Release(ReleaseOpt),
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clone, StructOpt)]
 pub struct ReleaseOpt {
     #[structopt(flatten)]
     pub manifest: clap_cargo::Manifest,
@@ -70,7 +70,7 @@ impl ReleaseOpt {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clone, StructOpt)]
 pub struct ConfigArgs {
     /// Sign both git commit and tag,
     #[structopt(long, overrides_with("no-sign"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,20 +88,26 @@ fn release_workspace(args: &args::ReleaseOpt) -> Result<i32, error::FatalError> 
         .filter_map(|id| pkg_releases.get(id))
         .collect();
 
-    let excluded_pkgs: Vec<_> = excluded_pkgs
-        .iter()
-        .filter(|p| pkg_ids.contains(&&p.id))
-        .filter_map(|p| PackageRelease::load(args, &root, &ws_meta, p).transpose())
-        .collect();
-    for pkg in excluded_pkgs {
-        let pkg = match pkg {
-            Ok(pkg) => pkg,
-            Err(err) => {
-                log::debug!("Could not analyze skipped package: {}", err);
-                continue;
-            }
-        };
-        if pkg.version.is_some() {
+    if !excluded_pkgs.is_empty() {
+        // We aren't releasing these, so keep the target version the same rather than attempting to
+        // change it which can be especially bad when an absolute version is used and the target
+        // version becomes a downgrade.
+        let mut excluded_args = args.clone();
+        excluded_args.level_or_version =
+            version::TargetVersion::Relative(version::BumpLevel::Release);
+        let excluded_pkgs: Vec<_> = excluded_pkgs
+            .iter()
+            .filter(|p| pkg_ids.contains(&&p.id))
+            .filter_map(|p| PackageRelease::load(&excluded_args, &root, &ws_meta, p).transpose())
+            .collect();
+        for pkg in excluded_pkgs {
+            let pkg = match pkg {
+                Ok(pkg) => pkg,
+                Err(err) => {
+                    log::debug!("Could not analyze skipped package: {}", err);
+                    continue;
+                }
+            };
             let crate_name = pkg.meta.name.as_str();
             let prev_tag_name = &pkg.prev_tag;
             if let Some((changed, lock_changed)) = changed_since(&ws_meta, &pkg, prev_tag_name) {


### PR DESCRIPTION
If a user used an absolute version for one crate but it is a downgrade
for another crate, our reporting missed changes in that excluded crate
will cause the entire operation to fail.

Logging should not cause regular operations to fail.

Fixes #370