### PR TITLE
feat(git): Allow shared tags 

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -74,6 +74,11 @@ quick_error! {
             source(err)
             display("{}", err)
         }
+        Git2Error(err: git2::Error) {
+            from()
+            source(err)
+            display("{}", err)
+        }
         NoPackage {
             display("No package in manifest file")
         }
@@ -108,7 +113,7 @@ quick_error! {
             source(err)
             display("Environment Variable Error: {}", err)
         }
-        GitError {
+        GitBinError {
             display("git is not found. git is required for cargo-release workflow.")
         }
         PublishTimeoutError {

--- a/src/git.rs
+++ b/src/git.rs
@@ -46,15 +46,11 @@ pub fn is_behind_remote(dir: &Path, remote: &str, branch: &str) -> Result<bool, 
 }
 
 pub fn current_branch(dir: &Path) -> Result<String, FatalError> {
-    let output = Command::new("git")
-        .arg("rev-parse")
-        .arg("--abbrev-ref")
-        .arg("HEAD")
-        .current_dir(dir)
-        .output()
-        .map_err(FatalError::from)?;
-    let branch = String::from_utf8(output.stdout)?.trim().to_owned();
-    Ok(branch)
+    let repo = git2::Repository::discover(dir)?;
+
+    let resolved = repo.head()?.resolve()?;
+    let name = resolved.shorthand().unwrap_or("HEAD");
+    Ok(name.to_owned())
 }
 
 pub fn is_dirty(dir: &Path) -> Result<bool, FatalError> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -140,6 +140,13 @@ pub fn tag(
     )
 }
 
+pub fn tag_exists(dir: &Path, name: &str) -> Result<bool, FatalError> {
+    let repo = git2::Repository::discover(dir)?;
+
+    let names = repo.tag_names(Some(name))?;
+    Ok(!names.is_empty())
+}
+
 pub fn push(
     dir: &Path,
     remote: &str,

--- a/src/release.rs
+++ b/src/release.rs
@@ -16,7 +16,7 @@ pub(crate) fn release_workspace(args: &args::ReleaseOpt) -> Result<i32, error::F
     let ws_meta = args
         .manifest
         .metadata()
-        // When evaluating dependency ordering, we need to consider optional depednencies
+        // When evaluating dependency ordering, we need to consider optional dependencies
         .features(cargo_metadata::CargoOpt::AllFeatures)
         .exec()
         .map_err(FatalError::from)?;

--- a/src/release.rs
+++ b/src/release.rs
@@ -152,13 +152,16 @@ fn release_packages<'m>(
     }
 
     let mut tag_exists = false;
+    let mut seen_tags = HashSet::new();
     for pkg in pkgs {
         if let Some(tag_name) = pkg.tag.as_ref() {
-            let cwd = pkg.package_path;
-            if git::tag_exists(cwd, tag_name)? {
-                let crate_name = pkg.meta.name.as_str();
-                log::error!("Tag `{}` already exists (for `{}`)", tag_name, crate_name);
-                tag_exists = true;
+            if seen_tags.insert(tag_name) {
+                let cwd = pkg.package_path;
+                if git::tag_exists(cwd, tag_name)? {
+                    let crate_name = pkg.meta.name.as_str();
+                    log::error!("Tag `{}` already exists (for `{}`)", tag_name, crate_name);
+                    tag_exists = true;
+                }
             }
         }
     }
@@ -442,33 +445,36 @@ fn release_packages<'m>(
     }
 
     // STEP 5: Tag
+    let mut seen_tags = HashSet::new();
     for pkg in pkgs {
         if let Some(tag_name) = pkg.tag.as_ref() {
-            let sign = pkg.config.sign_commit() || pkg.config.sign_tag();
+            if seen_tags.insert(tag_name) {
+                let sign = pkg.config.sign_commit() || pkg.config.sign_tag();
 
-            // FIXME: remove when the meaning of sign_commit is changed
-            if !pkg.config.sign_tag() && pkg.config.sign_commit() {
-                log::warn!("In next minor release, `sign-commit` will only be used to control git commit signing. Use option `sign-tag` for tag signing.");
-            }
+                // FIXME: remove when the meaning of sign_commit is changed
+                if !pkg.config.sign_tag() && pkg.config.sign_commit() {
+                    log::warn!("In next minor release, `sign-commit` will only be used to control git commit signing. Use option `sign-tag` for tag signing.");
+                }
 
-            let cwd = pkg.package_path;
-            let crate_name = pkg.meta.name.as_str();
+                let cwd = pkg.package_path;
+                let crate_name = pkg.meta.name.as_str();
 
-            let base = pkg.version.as_ref().unwrap_or(&pkg.prev_version);
-            let template = Template {
-                prev_version: Some(&pkg.prev_version.full_version_string),
-                version: Some(&base.full_version_string),
-                crate_name: Some(crate_name),
-                tag_name: Some(tag_name),
-                date: Some(NOW.as_str()),
-                ..Default::default()
-            };
-            let tag_message = template.render(pkg.config.tag_message());
+                let base = pkg.version.as_ref().unwrap_or(&pkg.prev_version);
+                let template = Template {
+                    prev_version: Some(&pkg.prev_version.full_version_string),
+                    version: Some(&base.full_version_string),
+                    crate_name: Some(crate_name),
+                    tag_name: Some(tag_name),
+                    date: Some(NOW.as_str()),
+                    ..Default::default()
+                };
+                let tag_message = template.render(pkg.config.tag_message());
 
-            log::debug!("Creating git tag {}", tag_name);
-            if !git::tag(cwd, tag_name, &tag_message, sign, dry_run)? {
-                // tag failed, abort release
-                return Ok(104);
+                log::debug!("Creating git tag {}", tag_name);
+                if !git::tag(cwd, tag_name, &tag_message, sign, dry_run)? {
+                    // tag failed, abort release
+                    return Ok(104);
+                }
             }
         }
     }
@@ -554,6 +560,7 @@ fn release_packages<'m>(
     }
 
     // STEP 7: git push
+    let mut seen_tags = HashSet::new();
     if ws_config.push() {
         let mut shared_push = false;
         for pkg in pkgs {
@@ -563,9 +570,11 @@ fn release_packages<'m>(
 
             let cwd = pkg.package_path;
             if let Some(tag_name) = pkg.tag.as_ref() {
-                log::info!("Pushing {} to {}", tag_name, git_remote);
-                if !git::push_tag(cwd, git_remote, tag_name, dry_run)? {
-                    return Ok(106);
+                if seen_tags.insert(tag_name) {
+                    log::info!("Pushing {} to {}", tag_name, git_remote);
+                    if !git::push_tag(cwd, git_remote, tag_name, dry_run)? {
+                        return Ok(106);
+                    }
                 }
             }
 


### PR DESCRIPTION
Just by naming two tags the same, they are shared.  To help catch
problems with this, we added support for detecting a tag
already exists.

Ideally, this is only used with `shared-version = true`.

I wanted to implement this using git2, so I started off porting some other code to git2.  I didn't do too much more out of laziness.

Fixes #333