### PR TITLE
fix(template)!: Var {{version}} now excludes metadata

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -97,8 +97,11 @@ See [release.toml](https://github.com/crate-ci/cargo-release/blob/master/release
 The following placeholders in configuration values will be be replaced with the desired value:
 
 * `{{prev_version}}`: The version before `cargo-release` was executed (before any version bump).
+* `{{prev_metadata}}`: The version's metadata before `cargo-release` was executed (before any version bump).
 * `{{version}}`: The current (bumped) crate version.
+* `{{metadata}}`: The current (bumped) crate version's metadata field.
 * `{{next_version}}` (only valid for `post-release-{commit-message,replacements}`): The crate version for starting development.
+* `{{next_metadata}}` (only valid for `post-release-{commit-message,replacements}`): The crate version's metadata field for starting development.
 * `{{crate_name}}`: The name of the current crate in `Cargo.toml`.
 * `{{date}}`: The current date in `%Y-%m-%d` format.
 * `{{prefix}}` (only valid for `tag-name` / `tag-message`): The value prepended to the tag name.
@@ -109,7 +112,9 @@ The following placeholders in configuration values will be be replaced with the 
 The following environment variables are made available to `pre-release-hook`:
 
 * `PREV_VERSION`: The version before `cargo-release` was executed (before any version bump).
+* `PREV_METADATA`: The version's metadata field before `cargo-release` was executed (before any version bump).
 * `NEW_VERSION`: The current (bumped) crate version.
+* `NEW_METADATA`: The current (bumped) crate version's metadata field.
 * `DRY_RUN`: Whether the release is actually happening (`true` / `false`)
 * `CRATE_NAME`: The current (bumped) crate version.
 * `WORKSPACE_ROOT`: The path to the workspace.

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -9,13 +9,16 @@ use crate::error::FatalError;
 #[derive(Clone, Default, Debug)]
 pub struct Template<'a> {
     pub prev_version: Option<&'a str>,
+    pub prev_metadata: Option<&'a str>,
     pub version: Option<&'a str>,
+    pub metadata: Option<&'a str>,
     pub crate_name: Option<&'a str>,
     pub date: Option<&'a str>,
 
     pub prefix: Option<&'a str>,
     pub tag_name: Option<&'a str>,
     pub next_version: Option<&'a str>,
+    pub next_metadata: Option<&'a str>,
 }
 
 impl<'a> Template<'a> {
@@ -24,8 +27,14 @@ impl<'a> Template<'a> {
         if let Some(prev_version) = self.prev_version {
             s = s.replace("{{prev_version}}", prev_version);
         }
+        if let Some(prev_metadata) = self.prev_metadata {
+            s = s.replace("{{prev_metadata}}", prev_metadata);
+        }
         if let Some(version) = self.version {
             s = s.replace("{{version}}", version);
+        }
+        if let Some(metadata) = self.metadata {
+            s = s.replace("{{metadata}}", metadata);
         }
         if let Some(crate_name) = self.crate_name {
             s = s.replace("{{crate_name}}", crate_name);
@@ -42,6 +51,9 @@ impl<'a> Template<'a> {
         }
         if let Some(next_version) = self.next_version {
             s = s.replace("{{next_version}}", next_version);
+        }
+        if let Some(next_metadata) = self.next_metadata {
+            s = s.replace("{{next_metadata}}", next_metadata);
         }
         s
     }


### PR DESCRIPTION
This gives users more control over when metadata shows up in versions
(like updating changelogs, example `Cargo.toml` dependencies, etc).
This also allows specifying only the metadata in places.

BREAKING CHANGE: To get old `{{version}}`, do
`{{version}}+{{metadata}}`.  Note that this impacts the default tags.

Fixes #308