### PR TITLE
fix(version): Populate metadata field on absolute versions

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -30,6 +30,8 @@ impl TargetVersion {
                     if full_version.build.is_empty() {
                         if let Some(metadata) = metadata {
                             full_version.build = semver::BuildMetadata::new(metadata)?;
+                        } else {
+                            full_version.build = current.build.clone();
                         }
                     }
                     Ok(Some(Version::from(full_version)))

--- a/src/version.rs
+++ b/src/version.rs
@@ -26,7 +26,12 @@ impl TargetVersion {
             }
             TargetVersion::Absolute(version) => {
                 if current < version {
-                    let full_version = version.to_owned();
+                    let mut full_version = version.to_owned();
+                    if full_version.build.is_empty() {
+                        if let Some(metadata) = metadata {
+                            full_version.build = semver::BuildMetadata::new(metadata)?;
+                        }
+                    }
                     Ok(Some(Version::from(full_version)))
                 } else if current == version {
                     Ok(None)


### PR DESCRIPTION
This only does it when the user didn't specify anything.  Probably should make double-specifying it an error.