### PR TITLE
fix(git): Match dirty check with our commits

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -109,26 +109,8 @@ fn release_packages<'m>(
     // STEP 0: Help the user make the right decisions.
     git::git_version()?;
 
-    let mut dirty = false;
-    if ws_config.consolidate_commits() {
-        if git::is_dirty(ws_meta.workspace_root.as_std_path())? {
-            log::error!("Uncommitted changes detected, please commit before release.");
-            dirty = true;
-        }
-    } else {
-        for pkg in pkgs {
-            let cwd = pkg.package_path;
-            if git::is_dirty(cwd)? {
-                let crate_name = pkg.meta.name.as_str();
-                log::error!(
-                    "Uncommitted changes detected for {}, please commit before release.",
-                    crate_name
-                );
-                dirty = true;
-            }
-        }
-    }
-    if dirty {
+    if git::is_dirty(ws_meta.workspace_root.as_std_path())? {
+        log::error!("Uncommitted changes detected, please commit before release.");
         if !dry_run {
             return Ok(101);
         }


### PR DESCRIPTION
When skipping consolidated commits, we check each released packages
directory for dirty but we commit files in all locations.  We need to
commit all because editing a package can modify the lock file or other
crate's dependencies.  So we change the dirty check to match commit.

Inspired by #336