### PR TITLE
feat: Allow specifying build target

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -73,6 +73,7 @@ Configuration is read from the following (in precedence order)
 | `pre-release-hook` | \-          | list of arguments           | \-                         | Provide a command to run before `cargo-release` commits version change. If the return code of hook command is greater than 0, the release process will be aborted. |
 | `enable-features` | `--features` | list of names               | `[]`                       | Provide a set of feature flags that should be passed to `cargo publish` (requires rust 1.33+) |
 | `enable-all-features` | `--all-features` | bool                | `false`                    | Signal to `cargo publish`, that all features should be used (requires rust 1.33+) |
+| `target`       | \-              | string                      | \-           | Target triple to use for the verification build |
 
 ### Supported Environment Variables
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -155,6 +155,10 @@ pub struct ConfigArgs {
     /// Enable all features via `all-features`. Overrides `features`
     #[clap(long)]
     all_features: bool,
+
+    /// Build for the target triple
+    #[clap(long)]
+    target: Option<String>,
 }
 
 impl ConfigArgs {
@@ -176,6 +180,7 @@ impl ConfigArgs {
             enable_features: (!self.features.is_empty()).then(|| self.features.clone()),
             enable_all_features: self.all_features.then(|| true),
             dependent_version: self.dependent_version,
+            target: self.target.clone(),
             ..Default::default()
         }
     }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -57,6 +57,7 @@ pub fn publish(
     features: &Features,
     registry: Option<&str>,
     token: Option<&str>,
+    target: Option<&str>,
 ) -> Result<bool, FatalError> {
     let cargo = cargo();
 
@@ -84,6 +85,11 @@ pub fn publish(
 
     if !verify {
         command.push("--no-verify");
+    }
+
+    if let Some(target) = target {
+        command.push("--target");
+        command.push(target);
     }
 
     let feature_arg;

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub struct Config {
     pub enable_features: Option<Vec<String>>,
     pub enable_all_features: Option<bool>,
     pub dependent_version: Option<DependentVersion>,
+    pub target: Option<String>,
 }
 
 impl Config {
@@ -83,6 +84,7 @@ impl Config {
             enable_features: Some(empty.enable_features().to_vec()),
             enable_all_features: Some(empty.enable_all_features()),
             dependent_version: Some(empty.dependent_version()),
+            target: None,
         }
     }
 
@@ -167,6 +169,9 @@ impl Config {
         }
         if let Some(dependent_version) = source.dependent_version {
             self.dependent_version = Some(dependent_version);
+        }
+        if let Some(target) = source.target.as_deref() {
+            self.target = Some(target.to_owned());
         }
     }
 

--- a/src/release.rs
+++ b/src/release.rs
@@ -491,6 +491,7 @@ fn release_packages<'m>(
             features,
             pkg.config.registry(),
             args.token.as_ref().map(AsRef::as_ref),
+            pkg.config.target.as_ref().map(AsRef::as_ref),
         )? {
             return Ok(103);
         }


### PR DESCRIPTION
Add `target` to the config (and `--target` argument) allowing the
verification build to be done against a different target triple. This is
helpful for crates that don't build with the default host target triple.