### PR TITLE
fix(cli): Fix help text for --verbose

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -198,8 +198,8 @@ pub struct Verbosity {
 
     /// Pass many times for more log output
     ///
-    /// By default, it'll report info. Passing `-v` one time also prints
-    /// warnings, `-vv` enables info logging, `-vvv` debug, and `-vvvv` trace.
+    /// By default, it'll report info. Passing `-v` one time adds debug
+    /// logs, `-vv` adds trace logs.
     #[clap(long, short, parse(from_occurrences))]
     verbose: i8,
 }


### PR DESCRIPTION
The default verbosity is 2, which corresponds to info logging. Adding a
single `-v` adds debug logging, and a second one adds trace logging,
which is the most verbose level.