### PR TITLE
refactor: Move off of chronoe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,6 @@ dependencies = [
  "assert_fs",
  "bstr",
  "cargo_metadata",
- "chrono",
  "clap",
  "clap-cargo",
  "crates-index",
@@ -110,6 +109,7 @@ dependencies = [
  "semver",
  "serde",
  "termcolor",
+ "time",
  "toml_edit",
 ]
 
@@ -140,19 +140,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi",
-]
 
 [[package]]
 name = "clap"
@@ -565,22 +552,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -938,13 +924,21 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
+ "itoa",
  "libc",
- "winapi",
+ "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bstr = "0.2.17"
 termcolor = "1.0"
 maplit = "1.0"
 indexmap = "1.8"
-chrono = "0.4"
+time = { version = "0.3", features = ["formatting", "macros"] }
 dirs-next = "2.0"
 ignore = "0.4"
 difflib = "0.4"

--- a/src/release.rs
+++ b/src/release.rs
@@ -3,7 +3,6 @@ use std::ffi::OsStr;
 use std::io::Write;
 use std::path::Path;
 
-use chrono::prelude::Local;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use itertools::Itertools;
@@ -711,8 +710,11 @@ fn release_packages<'m>(
     Ok(0)
 }
 
-static NOW: once_cell::sync::Lazy<String> =
-    once_cell::sync::Lazy::new(|| Local::now().format("%Y-%m-%d").to_string());
+static NOW: once_cell::sync::Lazy<String> = once_cell::sync::Lazy::new(|| {
+    time::OffsetDateTime::now_utc()
+        .format(time::macros::format_description!("[year]-[month]-[day]"))
+        .unwrap()
+});
 
 fn find_dependents<'w>(
     ws_meta: &'w cargo_metadata::Metadata,


### PR DESCRIPTION
Since chrono has been so slow to progress, going ahead and switching to
`time`.  Personally, I find the `time` API annoying.

This has a slight behavior change.  We are now returning the
year/month/day in UTC rather than local time.  That won't usually be
different and most peoples intended audience is the internet and your
local time doesn't matter to them.