### PR TITLE
Improve changelog example and regex options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +111,7 @@ dependencies = [
  "difflib",
  "dirs-next",
  "env_logger",
+ "fancy-regex",
  "git2",
  "ignore",
  "indexmap",
@@ -105,7 +121,6 @@ dependencies = [
  "once_cell",
  "predicates",
  "quick-error",
- "regex",
  "semver",
  "serde",
  "termcolor",
@@ -316,6 +331,16 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0678ab2d46fa5195aaf59ad034c083d351377d4af57f3e073c074d0da3e3c766"
+dependencies = [
+ "bit-set",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ toml_edit = { version = "0.14.3", features = ["easy"] }
 serde = { version = "1.0", features = ["derive"] }
 semver = "1.0"
 quick-error = "2.0"
-regex = "1.5"
+fancy-regex = "0.10"
 bstr = "0.2.17"
 termcolor = "1.0"
 maplit = "1.0"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -109,9 +109,10 @@ replace = "{{date}}"
 
 [[pre-release-replacements]]
 # Remove section headings with no content (other than empty lists)
-# https://regex101.com/r/sInwGH/1
+# fancy_regex has no multiline mode so we need to be explicit
+# https://regex101.com/r/NCL8bP/1
 file = "../../CHANGELOG.md"
-search = '''^### (?:Added|Changed|Deprecated|Removed|Fixed|Security)(?:\s|^-)+(?=^#)'''
+search = '''(?<=^|\n|\n\r)### (?:Added|Changed|Deprecated|Removed|Fixed|Security)(?:\s|(?:^|\n|\n\r)-)+(?:\n|\n\r)(?=#)'''
 replace = ""
 min = 0
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -96,7 +96,8 @@ Note: fields are from the package-configuration unless otherwise specified.
 This field is an array of tables with the following
 
 * `file`: the file to search and replace
-* `search`: regex that matches string you want to replace
+* `search`: regex that matches string you want to replace, using [fancy_regex](https://crates.io/crates/fancy-regex)
+  (essentially PCRE)
 * `replace`: the replacement string; you can use the any of the placeholders mentioned below.
 * `min` (default is `1`): Minimum occurrences of `search`.
 * `max` (optional): Maximum occurrences of `search`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::string::FromUtf8Error;
 
 use cargo_metadata::Error as CargoMetaError;
 use quick_error::quick_error;
-use regex::Error as RegexError;
+use fancy_regex::Error as RegexError;
 use semver::Error as SemVerError;
 use toml_edit::easy::de::Error as TomlDeError;
 use toml_edit::easy::ser::Error as TomlSerError;

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use fancy_regex::RegexBuilder;
+
 use crate::config::Replace;
 use crate::error::FatalError;
 
@@ -87,8 +89,8 @@ pub fn do_file_replacements(
             }
 
             let pattern = replace.search.as_str();
-            let r = regex::RegexBuilder::new(pattern)
-                .multi_line(true)
+            let r = RegexBuilder::new(pattern)
+                // .multi_line(true) Not available with fancy_regex
                 .build()
                 .map_err(FatalError::from)?;
 


### PR DESCRIPTION
This PR adds some nicer configuration for the example automatic changelog:

- Change to TOML non-inlined tables for easier readability
- Automatically add all available sections recommended on https://keepachangelog.com
- Added some clarification on the location of these changelog-helper files
- Switch from `regex` to `fancy_regex`, which is a drop-in replacement that enables PCRE (lookarounds and backrefs), as needed for some nicer automatic format features