### PR TITLE
Add `--allow-dirty` flag

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,16 +2,17 @@
 
 ## CLI Arguments
 
-| Argument        | Format | Description |
-|-----------------|--------|-------------|
-| `--execute`     | bool   | Actually perform the release |
+| Argument        | Format | Description                                                    |
+|-----------------|--------|----------------------------------------------------------------|
+| `--execute`     | bool   | Actually perform the release                                   |
 | `--no-confirm`  | bool   | Release the crate without the user verifying what will happen. |
-| `--isolated`    | bool   | Do not search for config files |
-| `--config`      | string | Load a config file from disk |
-| `<LEVEL>`       | string | Bump specified version field. |
-| `--metadata`    | string | Populate the metadata field in the version. |
-| `--token`       | string | Token to use when running `cargo publish` |
-| `--verbose`     | bool   | Show more detailed context, useful for debugging |
+| `--isolated`    | bool   | Do not search for config files                                 |
+| `--config`      | string | Load a config file from disk                                   |
+| `<LEVEL>`       | string | Bump specified version field.                                  |
+| `--metadata`    | string | Populate the metadata field in the version.                    |
+| `--token`       | string | Token to use when running `cargo publish`                      |
+| `--verbose`     | bool   | Show more detailed context, useful for debugging               |
+| `--allow-dirty` | bool   | Allow dirty working directories to be released.                |
 
 ### Bump level
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -65,6 +65,10 @@ pub struct ReleaseOpt {
 
     #[clap(flatten)]
     pub logging: Verbosity,
+
+    /// Allow dirty working directories to be released.
+    #[clap(long)]
+    pub allow_dirty: bool,
 }
 
 impl ReleaseOpt {

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -58,6 +58,7 @@ pub fn publish(
     registry: Option<&str>,
     token: Option<&str>,
     target: Option<&str>,
+    allow_dirty: bool,
 ) -> Result<bool, FatalError> {
     let cargo = cargo();
 
@@ -85,6 +86,9 @@ pub fn publish(
 
     if dry_run {
         command.push("--dry-run");
+    }
+
+    if dry_run || allow_dirty {
         command.push("--allow-dirty");
     }
 

--- a/src/release.rs
+++ b/src/release.rs
@@ -126,8 +126,8 @@ fn release_packages<'m>(
     // STEP 0: Help the user make the right decisions.
     git::git_version()?;
 
-    if git::is_dirty(ws_meta.workspace_root.as_std_path())? {
-        log::error!("Uncommitted changes detected, please commit before release.");
+    if !args.allow_dirty && git::is_dirty(ws_meta.workspace_root.as_std_path())? {
+        log::error!("Uncommitted changes detected, please commit before release, or re-run using `--dry-run`.");
         failed = true;
         if !dry_run {
             return Ok(101);
@@ -517,6 +517,7 @@ fn release_packages<'m>(
             pkg.config.registry(),
             args.token.as_ref().map(AsRef::as_ref),
             pkg.config.target.as_ref().map(AsRef::as_ref),
+            args.allow_dirty,
         )? {
             return Ok(103);
         }


### PR DESCRIPTION
When publishing [`ink!`](https://github.com/paritytech/ink) we tend to remove `dev-dependencies` across our workspace before
publishing due to some cyclic dependencies. It would be nice to be able to remove them
temporarily and still be able to publish using `cargo-release`.

I'm not sure if there's any way to write tests for this, but if there is let me know and
I can add them.

Supersedes https://github.com/crate-ci/cargo-release/pull/196.

P.S cool tool!
