### PR TITLE
fix!: Remove `--token`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -48,10 +48,6 @@ pub struct ReleaseOpt {
     #[command(flatten)]
     pub config: crate::config::ConfigArgs,
 
-    /// Token to use when uploading
-    #[arg(long)]
-    pub token: Option<String>,
-
     /// Actually perform a release. Dry-run mode is the default
     #[arg(short = 'x', long)]
     pub execute: bool,

--- a/src/ops/cargo.rs
+++ b/src/ops/cargo.rs
@@ -56,7 +56,6 @@ pub fn publish(
     pkgid: Option<&str>,
     features: &Features,
     registry: Option<&str>,
-    token: Option<&str>,
     target: Option<&str>,
 ) -> Result<bool, FatalError> {
     let cargo = cargo();
@@ -76,11 +75,6 @@ pub fn publish(
     if let Some(registry) = registry {
         command.push("--registry");
         command.push(registry);
-    }
-
-    if let Some(token) = token {
-        command.push("--token");
-        command.push(token);
     }
 
     if dry_run {

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -34,10 +34,6 @@ pub struct PublishStep {
 
     #[command(flatten)]
     publish: crate::config::PublishArgs,
-
-    /// Token to use when uploading
-    #[arg(long)]
-    token: Option<String>,
 }
 
 impl PublishStep {
@@ -114,8 +110,7 @@ impl PublishStep {
         super::confirm("Publish", &pkgs, self.no_confirm, dry_run)?;
 
         // STEP 3: cargo publish
-        let token = self.token.as_ref().map(AsRef::as_ref);
-        publish(&ws_meta, &pkgs, token, dry_run)?;
+        publish(&ws_meta, &pkgs, dry_run)?;
 
         super::finish(failed, dry_run)
     }
@@ -134,7 +129,6 @@ impl PublishStep {
 pub fn publish(
     ws_meta: &cargo_metadata::Metadata,
     pkgs: &[plan::PackageRelease],
-    token: Option<&str>,
     dry_run: bool,
 ) -> Result<(), ProcessError> {
     let index = crates_index::Index::new_cargo_default()?;
@@ -178,7 +172,6 @@ pub fn publish(
             pkgid,
             features,
             pkg.config.registry(),
-            token,
             pkg.config.target.as_ref().map(AsRef::as_ref),
         )? {
             return Err(103.into());

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -289,8 +289,7 @@ fn release_packages<'m>(
     }
 
     // STEP 3: cargo publish
-    let token = args.token.as_ref().map(AsRef::as_ref);
-    super::publish::publish(ws_meta, pkgs, token, dry_run)?;
+    super::publish::publish(ws_meta, pkgs, dry_run)?;
 
     // STEP 5: Tag
     super::tag::tag(pkgs, dry_run)?;


### PR DESCRIPTION
> We may consider deprecating --token in the far future. We are trying
> to move away from passing secrets on the command-line, due to the
> relatively high risk of leaking a secret.

https://github.com/rust-lang/cargo/issues/11136