### PR TITLE
fix!: Do full release process for existing crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "dirs-next",
  "env_logger",
  "git2",
+ "globset",
  "ignore",
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ clap = { version = "4.0.8", features = ["derive", "wrap_help"] }
 clap-cargo = { version = "0.10.0", features = ["cargo_metadata"] }
 log = "0.4"
 env_logger = "0.9"
+globset = { version = "0.4.9", default-features = false }
 
 [dev-dependencies]
 assert_fs = "1.0"

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -199,59 +199,58 @@ pub fn warn_changed(
 ) -> Result<(), crate::error::ProcessError> {
     let mut changed_pkgs = std::collections::HashSet::new();
     for pkg in pkgs {
-        if let Some(version) = pkg.planned_version.as_ref() {
-            let crate_name = pkg.meta.name.as_str();
-            if let Some(prior_tag_name) = &pkg.prior_tag {
-                if let Some((changed, lock_changed)) =
-                    crate::steps::version::changed_since(ws_meta, pkg, prior_tag_name)
-                {
-                    if !changed.is_empty() {
-                        log::debug!(
-                            "Files changed in {} since {}: {:#?}",
-                            crate_name,
-                            prior_tag_name,
-                            changed
-                        );
-                        changed_pkgs.insert(&pkg.meta.id);
-                        changed_pkgs.extend(pkg.dependents.iter().map(|d| &d.pkg.id));
-                    } else if changed_pkgs.contains(&pkg.meta.id) {
-                        log::debug!(
-                            "Dependency changed for {} since {}",
-                            crate_name,
-                            prior_tag_name,
-                        );
-                        changed_pkgs.insert(&pkg.meta.id);
-                        changed_pkgs.extend(pkg.dependents.iter().map(|d| &d.pkg.id));
-                    } else if lock_changed {
-                        log::debug!(
-                            "Lock file changed for {} since {}, assuming its relevant",
-                            crate_name,
-                            prior_tag_name
-                        );
-                        changed_pkgs.insert(&pkg.meta.id);
-                        // Lock file changes don't invalidate dependents, which is why this check is
-                        // after the transitive check, so that can invalidate dependents
-                    } else {
-                        log::warn!(
-                            "Updating {} to {} despite no changes made since tag {}",
-                            crate_name,
-                            version.full_version_string,
-                            prior_tag_name
-                        );
-                    }
-                } else {
+        let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
+        let crate_name = pkg.meta.name.as_str();
+        if let Some(prior_tag_name) = &pkg.prior_tag {
+            if let Some((changed, lock_changed)) =
+                crate::steps::version::changed_since(ws_meta, pkg, prior_tag_name)
+            {
+                if !changed.is_empty() {
                     log::debug!(
-                        "Cannot detect changes for {} because tag {} is missing. Try setting `--prev-tag-name <TAG>`.",
+                        "Files changed in {} since {}: {:#?}",
                         crate_name,
+                        prior_tag_name,
+                        changed
+                    );
+                    changed_pkgs.insert(&pkg.meta.id);
+                    changed_pkgs.extend(pkg.dependents.iter().map(|d| &d.pkg.id));
+                } else if changed_pkgs.contains(&pkg.meta.id) {
+                    log::debug!(
+                        "Dependency changed for {} since {}",
+                        crate_name,
+                        prior_tag_name,
+                    );
+                    changed_pkgs.insert(&pkg.meta.id);
+                    changed_pkgs.extend(pkg.dependents.iter().map(|d| &d.pkg.id));
+                } else if lock_changed {
+                    log::debug!(
+                        "Lock file changed for {} since {}, assuming its relevant",
+                        crate_name,
+                        prior_tag_name
+                    );
+                    changed_pkgs.insert(&pkg.meta.id);
+                    // Lock file changes don't invalidate dependents, which is why this check is
+                    // after the transitive check, so that can invalidate dependents
+                } else {
+                    log::warn!(
+                        "Updating {} to {} despite no changes made since tag {}",
+                        crate_name,
+                        version.full_version_string,
                         prior_tag_name
                     );
                 }
             } else {
                 log::debug!(
+                        "Cannot detect changes for {} because tag {} is missing. Try setting `--prev-tag-name <TAG>`.",
+                        crate_name,
+                        prior_tag_name
+                    );
+            }
+        } else {
+            log::debug!(
                     "Cannot detect changes for {} because no tag was found. Try setting `--prev-tag-name <TAG>`.",
                     crate_name,
                 );
-            }
         }
     }
 

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -201,49 +201,55 @@ pub fn warn_changed(
     for pkg in pkgs {
         if let Some(version) = pkg.planned_version.as_ref() {
             let crate_name = pkg.meta.name.as_str();
-            let prior_tag_name = &pkg.prior_tag;
-            if let Some((changed, lock_changed)) =
-                crate::steps::version::changed_since(ws_meta, pkg, prior_tag_name)
-            {
-                if !changed.is_empty() {
-                    log::debug!(
-                        "Files changed in {} since {}: {:#?}",
-                        crate_name,
-                        prior_tag_name,
-                        changed
-                    );
-                    changed_pkgs.insert(&pkg.meta.id);
-                    changed_pkgs.extend(pkg.dependents.iter().map(|d| &d.pkg.id));
-                } else if changed_pkgs.contains(&pkg.meta.id) {
-                    log::debug!(
-                        "Dependency changed for {} since {}",
-                        crate_name,
-                        prior_tag_name,
-                    );
-                    changed_pkgs.insert(&pkg.meta.id);
-                    changed_pkgs.extend(pkg.dependents.iter().map(|d| &d.pkg.id));
-                } else if lock_changed {
-                    log::debug!(
-                        "Lock file changed for {} since {}, assuming its relevant",
-                        crate_name,
-                        prior_tag_name
-                    );
-                    changed_pkgs.insert(&pkg.meta.id);
-                    // Lock file changes don't invalidate dependents, which is why this check is
-                    // after the transitive check, so that can invalidate dependents
+            if let Some(prior_tag_name) = &pkg.prior_tag {
+                if let Some((changed, lock_changed)) =
+                    crate::steps::version::changed_since(ws_meta, pkg, prior_tag_name)
+                {
+                    if !changed.is_empty() {
+                        log::debug!(
+                            "Files changed in {} since {}: {:#?}",
+                            crate_name,
+                            prior_tag_name,
+                            changed
+                        );
+                        changed_pkgs.insert(&pkg.meta.id);
+                        changed_pkgs.extend(pkg.dependents.iter().map(|d| &d.pkg.id));
+                    } else if changed_pkgs.contains(&pkg.meta.id) {
+                        log::debug!(
+                            "Dependency changed for {} since {}",
+                            crate_name,
+                            prior_tag_name,
+                        );
+                        changed_pkgs.insert(&pkg.meta.id);
+                        changed_pkgs.extend(pkg.dependents.iter().map(|d| &d.pkg.id));
+                    } else if lock_changed {
+                        log::debug!(
+                            "Lock file changed for {} since {}, assuming its relevant",
+                            crate_name,
+                            prior_tag_name
+                        );
+                        changed_pkgs.insert(&pkg.meta.id);
+                        // Lock file changes don't invalidate dependents, which is why this check is
+                        // after the transitive check, so that can invalidate dependents
+                    } else {
+                        log::warn!(
+                            "Updating {} to {} despite no changes made since tag {}",
+                            crate_name,
+                            version.full_version_string,
+                            prior_tag_name
+                        );
+                    }
                 } else {
-                    log::warn!(
-                        "Updating {} to {} despite no changes made since tag {}",
+                    log::debug!(
+                        "Cannot detect changes for {} because tag {} is missing. Try setting `--prev-tag-name <TAG>`.",
                         crate_name,
-                        version.full_version_string,
                         prior_tag_name
                     );
                 }
             } else {
                 log::debug!(
-                    "Cannot detect changes for {} because tag {} is missing. Try setting `--prev-tag-name <TAG>`.",
+                    "Cannot detect changes for {} because no tag was found. Try setting `--prev-tag-name <TAG>`.",
                     crate_name,
-                    prior_tag_name
                 );
             }
         }

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -40,6 +40,8 @@ pub struct PublishStep {
 
 impl PublishStep {
     pub fn run(&self) -> Result<(), ProcessError> {
+        git::git_version()?;
+
         let ws_meta = self
             .manifest
             .metadata()
@@ -100,8 +102,6 @@ impl PublishStep {
         let mut failed = false;
 
         // STEP 0: Help the user make the right decisions.
-        git::git_version()?;
-
         failed |= !super::verify_git_is_clean(
             ws_meta.workspace_root.as_std_path(),
             dry_run,

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -72,7 +72,7 @@ impl PublishStep {
         for pkg in pkgs.values_mut() {
             if pkg.config.registry().is_none() && pkg.config.release() {
                 let crate_name = pkg.meta.name.as_str();
-                let version = &pkg.prev_version;
+                let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
                 if crate::ops::cargo::is_published(&index, crate_name, &version.full_version_string)
                 {
                     log::warn!(
@@ -154,8 +154,8 @@ pub fn publish(
         }
 
         let crate_name = pkg.meta.name.as_str();
-        if pkg.config.registry().is_none() && pkg.version.is_none() {
-            let version = &pkg.prev_version;
+        if pkg.config.registry().is_none() && pkg.planned_version.is_none() {
+            let version = &pkg.initial_version;
             if crate::ops::cargo::is_published(&index, crate_name, &version.full_version_string) {
                 log::warn!("Skipping publish of {} {}, assuming we are recovering from a prior failed release", crate_name, version.full_version_string);
                 continue;
@@ -197,7 +197,7 @@ pub fn publish(
             let mut index = crates_index::Index::new_cargo_default()?;
 
             let timeout = std::time::Duration::from_secs(300);
-            let version = pkg.version.as_ref().unwrap_or(&pkg.prev_version);
+            let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
             crate::ops::cargo::wait_for_publish(
                 &mut index,
                 crate_name,

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -147,21 +147,12 @@ pub fn publish(
     pkgs: &[plan::PackageRelease],
     dry_run: bool,
 ) -> Result<(), ProcessError> {
-    let index = crates_index::Index::new_cargo_default()?;
     for pkg in pkgs {
         if !pkg.config.publish() {
             continue;
         }
 
         let crate_name = pkg.meta.name.as_str();
-        if pkg.config.registry().is_none() && pkg.planned_version.is_none() {
-            let version = &pkg.initial_version;
-            if crate::ops::cargo::is_published(&index, crate_name, &version.full_version_string) {
-                log::warn!("Skipping publish of {} {}, assuming we are recovering from a prior failed release", crate_name, version.full_version_string);
-                continue;
-            }
-        }
-
         log::info!("Publishing {}", crate_name);
 
         let verify = if !pkg.config.verify() {

--- a/src/steps/push.rs
+++ b/src/steps/push.rs
@@ -43,6 +43,8 @@ pub struct PushStep {
 
 impl PushStep {
     pub fn run(&self) -> Result<(), ProcessError> {
+        git::git_version()?;
+
         let ws_meta = self
             .manifest
             .metadata()
@@ -84,8 +86,6 @@ impl PushStep {
         let mut failed = false;
 
         // STEP 0: Help the user make the right decisions.
-        git::git_version()?;
-
         failed |= !super::verify_git_is_clean(
             ws_meta.workspace_root.as_std_path(),
             dry_run,

--- a/src/steps/push.rs
+++ b/src/steps/push.rs
@@ -147,12 +147,12 @@ pub fn push(
 
             if pkg.config.consolidate_pushes() {
                 shared_refs.insert(branch.as_str());
-                if let Some(tag_name) = pkg.tag.as_deref() {
+                if let Some(tag_name) = pkg.planned_tag.as_deref() {
                     shared_refs.insert(tag_name);
                 }
             } else {
                 let mut refs = vec![branch.as_str()];
-                if let Some(tag_name) = pkg.tag.as_deref() {
+                if let Some(tag_name) = pkg.planned_tag.as_deref() {
                     refs.push(tag_name)
                 }
                 log::info!("Pushing {} to {}", refs.join(", "), git_remote);

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -46,6 +46,8 @@ pub struct ReleaseStep {
 
 impl ReleaseStep {
     pub fn run(&self) -> Result<(), ProcessError> {
+        git::git_version()?;
+
         let ws_meta = self
             .manifest
             .metadata()
@@ -142,8 +144,6 @@ fn release_packages<'m>(
     let mut failed = false;
 
     // STEP 0: Help the user make the right decisions.
-    git::git_version()?;
-
     failed |= !super::verify_git_is_clean(
         ws_meta.workspace_root.as_std_path(),
         dry_run,

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -77,36 +77,39 @@ impl ReleaseStep {
             pkg.planned_version = None;
 
             let crate_name = pkg.meta.name.as_str();
-            let prior_tag_name = &pkg.prior_tag;
-            if let Some((changed, lock_changed)) =
-                crate::steps::version::changed_since(&ws_meta, pkg, prior_tag_name)
-            {
-                if !changed.is_empty() {
-                    log::warn!(
-                        "Disabled by user, skipping {} which has files changed since {}: {:#?}",
-                        crate_name,
-                        prior_tag_name,
-                        changed
-                    );
-                } else if lock_changed {
-                    log::warn!(
+            if let Some(prior_tag_name) = &pkg.prior_tag {
+                if let Some((changed, lock_changed)) =
+                    crate::steps::version::changed_since(&ws_meta, pkg, prior_tag_name)
+                {
+                    if !changed.is_empty() {
+                        log::warn!(
+                            "Disabled by user, skipping {} which has files changed since {}: {:#?}",
+                            crate_name,
+                            prior_tag_name,
+                            changed
+                        );
+                    } else if lock_changed {
+                        log::warn!(
                         "Disabled by user, skipping {} despite lock file being changed since {}",
                         crate_name,
                         prior_tag_name
                     );
+                    } else {
+                        log::trace!(
+                            "Disabled by user, skipping {} (no changes since {})",
+                            crate_name,
+                            prior_tag_name
+                        );
+                    }
                 } else {
-                    log::trace!(
-                        "Disabled by user, skipping {} (no changes since {})",
+                    log::debug!(
+                        "Disabled by user, skipping {} (no {} tag)",
                         crate_name,
                         prior_tag_name
                     );
                 }
             } else {
-                log::debug!(
-                    "Disabled by user, skipping {} (no {} tag)",
-                    crate_name,
-                    prior_tag_name
-                );
+                log::debug!("Disabled by user, skipping {} (no tag found)", crate_name,);
             }
         }
 

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -21,11 +21,10 @@ pub struct ReleaseStep {
     workspace: clap_cargo::Workspace,
 
     /// Release level or version: bumping specified version field or remove prerelease extensions by default. Possible level value: major, minor, patch, release, rc, beta, alpha or any valid semver version that is greater than current version
-    #[arg(default_value_t)]
-    level_or_version: version::TargetVersion,
+    level_or_version: Option<version::TargetVersion>,
 
     /// Semver metadata
-    #[arg(short, long)]
+    #[arg(short, long, requires = "level_or_version")]
     metadata: Option<String>,
 
     #[command(flatten)]
@@ -64,7 +63,9 @@ impl ReleaseStep {
                 // they don't care about any changes from before this tag.
                 pkg.set_prior_tag(prev_tag.to_owned());
             }
-            pkg.bump(&self.level_or_version, self.metadata.as_deref())?;
+            if let Some(level_or_version) = &self.level_or_version {
+                pkg.bump(level_or_version, self.metadata.as_deref())?;
+            }
         }
 
         let (_selected_pkgs, excluded_pkgs) = self.workspace.partition_packages(&ws_meta);

--- a/src/steps/replace.rs
+++ b/src/steps/replace.rs
@@ -56,7 +56,7 @@ impl ReplaceStep {
                 continue;
             };
             pkg.config.release = Some(false);
-            pkg.version = None;
+            pkg.planned_version = None;
         }
 
         let pkgs = plan::plan(pkgs)?;
@@ -104,12 +104,12 @@ impl ReplaceStep {
 
         // STEP 2: update current version, save and commit
         for pkg in &pkgs {
-            let version = pkg.version.as_ref().unwrap_or(&pkg.prev_version);
+            let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
             if !pkg.config.pre_release_replacements().is_empty() {
                 let cwd = &pkg.package_root;
                 let crate_name = pkg.meta.name.as_str();
-                let prev_version_var = pkg.prev_version.bare_version_string.as_str();
-                let prev_metadata_var = pkg.prev_version.full_version.build.as_str();
+                let prev_version_var = pkg.initial_version.bare_version_string.as_str();
+                let prev_metadata_var = pkg.initial_version.full_version.build.as_str();
                 let version_var = version.bare_version_string.as_str();
                 let metadata_var = version.full_version.build.as_str();
                 // try replacing text in configured files
@@ -120,7 +120,7 @@ impl ReplaceStep {
                     metadata: Some(metadata_var),
                     crate_name: Some(crate_name),
                     date: Some(NOW.as_str()),
-                    tag_name: pkg.tag.as_deref(),
+                    tag_name: pkg.planned_tag.as_deref(),
                     ..Default::default()
                 };
                 let prerelease = version.is_prerelease();

--- a/src/steps/replace.rs
+++ b/src/steps/replace.rs
@@ -36,6 +36,8 @@ pub struct ReplaceStep {
 
 impl ReplaceStep {
     pub fn run(&self) -> Result<(), ProcessError> {
+        git::git_version()?;
+
         let ws_meta = self
             .manifest
             .metadata()
@@ -75,8 +77,6 @@ impl ReplaceStep {
         let mut failed = false;
 
         // STEP 0: Help the user make the right decisions.
-        git::git_version()?;
-
         failed |= !super::verify_git_is_clean(
             ws_meta.workspace_root.as_std_path(),
             dry_run,

--- a/src/steps/tag.rs
+++ b/src/steps/tag.rs
@@ -44,6 +44,8 @@ pub struct TagStep {
 
 impl TagStep {
     pub fn run(&self) -> Result<(), ProcessError> {
+        git::git_version()?;
+
         let ws_meta = self
             .manifest
             .metadata()
@@ -101,8 +103,6 @@ impl TagStep {
         let mut failed = false;
 
         // STEP 0: Help the user make the right decisions.
-        git::git_version()?;
-
         failed |= !super::verify_git_is_clean(
             ws_meta.workspace_root.as_std_path(),
             dry_run,

--- a/src/steps/tag.rs
+++ b/src/steps/tag.rs
@@ -72,7 +72,7 @@ impl TagStep {
         let mut pkgs = plan::plan(pkgs)?;
 
         for pkg in pkgs.values_mut() {
-            if let Some(tag_name) = pkg.tag.as_ref() {
+            if let Some(tag_name) = pkg.planned_tag.as_ref() {
                 if crate::ops::git::tag_exists(ws_meta.workspace_root.as_std_path(), tag_name)? {
                     let crate_name = pkg.meta.name.as_str();
                     log::warn!(
@@ -80,7 +80,7 @@ impl TagStep {
                         tag_name,
                         crate_name
                     );
-                    pkg.tag = None;
+                    pkg.planned_tag = None;
                     pkg.config.tag = Some(false);
                     pkg.config.release = Some(false);
                 }
@@ -146,14 +146,14 @@ impl TagStep {
 pub fn tag(pkgs: &[plan::PackageRelease], dry_run: bool) -> Result<(), ProcessError> {
     let mut seen_tags = HashSet::new();
     for pkg in pkgs {
-        if let Some(tag_name) = pkg.tag.as_ref() {
+        if let Some(tag_name) = pkg.planned_tag.as_ref() {
             if seen_tags.insert(tag_name) {
                 let cwd = &pkg.package_root;
                 let crate_name = pkg.meta.name.as_str();
 
-                let version = pkg.version.as_ref().unwrap_or(&pkg.prev_version);
-                let prev_version_var = pkg.prev_version.bare_version_string.as_str();
-                let prev_metadata_var = pkg.prev_version.full_version.build.as_str();
+                let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
+                let prev_version_var = pkg.initial_version.bare_version_string.as_str();
+                let prev_metadata_var = pkg.initial_version.full_version.build.as_str();
                 let version_var = version.bare_version_string.as_str();
                 let metadata_var = version.full_version.build.as_str();
                 let template = Template {

--- a/src/steps/version.rs
+++ b/src/steps/version.rs
@@ -48,6 +48,8 @@ pub struct VersionStep {
 
 impl VersionStep {
     pub fn run(&self) -> Result<(), ProcessError> {
+        git::git_version()?;
+
         let ws_meta = self
             .manifest
             .metadata()
@@ -131,8 +133,6 @@ impl VersionStep {
         let mut failed = false;
 
         // STEP 0: Help the user make the right decisions.
-        git::git_version()?;
-
         failed |= !super::verify_git_is_clean(
             ws_meta.workspace_root.as_std_path(),
             dry_run,

--- a/src/steps/version.rs
+++ b/src/steps/version.rs
@@ -80,34 +80,38 @@ impl VersionStep {
             pkg.planned_version = None;
 
             let crate_name = pkg.meta.name.as_str();
-            let prior_tag_name = &pkg.prior_tag;
-            if let Some((changed, lock_changed)) = changed_since(&ws_meta, pkg, prior_tag_name) {
-                if !changed.is_empty() {
-                    log::warn!(
-                        "Disabled by user, skipping {} which has files changed since {}: {:#?}",
-                        crate_name,
-                        prior_tag_name,
-                        changed
-                    );
-                } else if lock_changed {
-                    log::warn!(
+            if let Some(prior_tag_name) = &pkg.prior_tag {
+                if let Some((changed, lock_changed)) = changed_since(&ws_meta, pkg, prior_tag_name)
+                {
+                    if !changed.is_empty() {
+                        log::warn!(
+                            "Disabled by user, skipping {} which has files changed since {}: {:#?}",
+                            crate_name,
+                            prior_tag_name,
+                            changed
+                        );
+                    } else if lock_changed {
+                        log::warn!(
                         "Disabled by user, skipping {} despite lock file being changed since {}",
                         crate_name,
                         prior_tag_name
                     );
+                    } else {
+                        log::trace!(
+                            "Disabled by user, skipping {} (no changes since {})",
+                            crate_name,
+                            prior_tag_name
+                        );
+                    }
                 } else {
-                    log::trace!(
-                        "Disabled by user, skipping {} (no changes since {})",
+                    log::debug!(
+                        "Disabled by user, skipping {} (no {} tag)",
                         crate_name,
                         prior_tag_name
                     );
                 }
             } else {
-                log::debug!(
-                    "Disabled by user, skipping {} (no {} tag)",
-                    crate_name,
-                    prior_tag_name
-                );
+                log::debug!("Disabled by user, skipping {} (no tag found)", crate_name,);
             }
         }
 


### PR DESCRIPTION
Previously, `cargo release` was used both for
- Removing pre-release versions
- Recovering from a previous failure

With #530, we now expose the lower level mechanisms to allow people to recover in a more controlled manner and don't need high level recovery support that likely won't work in a users situation because its too abstract.  This opens the door for us to allow users to use the `cargo release version` step to modify versions as they please and release them

BREAKING CHANGE: `cargo release` no longer works as a recovery mode.  Instead, use the individual steps you need to recover

Fixes #482