### PR TITLE
fix(cli)!: Use consistent 101 exit code

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,7 +26,7 @@ impl ProcessError {
     pub fn message(e: impl Into<FatalError>) -> Self {
         Self {
             error: Some(e.into()),
-            code: 1,
+            code: 101,
         }
     }
 }

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -283,7 +283,7 @@ pub fn find_shared_versions(
     }
     if !is_shared {
         log::error!("Crate versions deviated, aborting");
-        return Err(110.into());
+        return Err(101.into());
     }
 
     Ok(shared_version)
@@ -333,7 +333,7 @@ pub fn finish(failed: bool, dry_run: bool) -> Result<(), crate::error::ProcessEr
     if dry_run {
         if failed {
             log::error!("Dry-run failed, resolve the above errors and try again.");
-            Err(107.into())
+            Err(101.into())
         } else {
             log::warn!("Ran a `dry-run`, re-run with `--execute` if all looked good.");
             Ok(())

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -182,7 +182,7 @@ pub fn publish(
             pkg.config.registry(),
             pkg.config.target.as_ref().map(AsRef::as_ref),
         )? {
-            return Err(103.into());
+            return Err(101.into());
         }
 
         if pkg.config.registry().is_none() {

--- a/src/steps/push.rs
+++ b/src/steps/push.rs
@@ -158,7 +158,7 @@ pub fn push(
                 log::info!("Pushing {} to {}", refs.join(", "), git_remote);
                 let cwd = &pkg.package_root;
                 if !git::push(cwd, git_remote, refs, pkg.config.push_options(), dry_run)? {
-                    return Err(106.into());
+                    return Err(101.into());
                 }
             }
         }
@@ -173,7 +173,7 @@ pub fn push(
                 ws_config.push_options(),
                 dry_run,
             )? {
-                return Err(106.into());
+                return Err(101.into());
             }
         }
     }

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -298,7 +298,7 @@ impl ReleaseStep {
                         "Release of {} aborted by non-zero return of prerelease hook.",
                         crate_name
                     );
-                    return Err(107.into());
+                    return Err(101.into());
                 }
             }
 
@@ -318,7 +318,7 @@ impl ReleaseStep {
                 let sign = pkg.config.sign_commit();
                 if !git::commit_all(cwd, &commit_msg, sign, dry_run)? {
                     // commit failed, abort release
-                    return Err(102.into());
+                    return Err(101.into());
                 }
             }
         }
@@ -345,7 +345,7 @@ impl ReleaseStep {
                 dry_run,
             )? {
                 // commit failed, abort release
-                return Err(102.into());
+                return Err(101.into());
             }
         }
 
@@ -419,7 +419,7 @@ impl ReleaseStep {
 
                     let commit_msg = template.render(pkg.config.post_release_commit_message());
                     if !git::commit_all(cwd, &commit_msg, sign, dry_run)? {
-                        return Err(105.into());
+                        return Err(101.into());
                     }
                 }
             }
@@ -455,7 +455,7 @@ impl ReleaseStep {
                 dry_run,
             )? {
                 // commit failed, abort release
-                return Err(102.into());
+                return Err(101.into());
             }
         }
 

--- a/src/steps/tag.rs
+++ b/src/steps/tag.rs
@@ -171,7 +171,7 @@ pub fn tag(pkgs: &[plan::PackageRelease], dry_run: bool) -> Result<(), ProcessEr
                 log::debug!("Creating git tag {}", tag_name);
                 if !git::tag(cwd, tag_name, &tag_message, pkg.config.sign_tag(), dry_run)? {
                     // tag failed, abort release
-                    return Err(104.into());
+                    return Err(101.into());
                 }
             }
         }


### PR DESCRIPTION
Our exit codes were a bit haphazard.  I think they were meant to represent the stage that failed but we haven't kept up with that (and new stages get added / removed).

I chose the exit code that cargo tends to use.