### PR TITLE
fix(publish): Bail out error for rate limits

### DIFF
--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -122,6 +122,8 @@ impl PublishStep {
             log::Level::Warn,
         )?;
 
+        failed |= !super::verify_rate_limit(&pkgs, &index, dry_run, log::Level::Error)?;
+
         // STEP 1: Release Confirmation
         super::confirm("Publish", &pkgs, self.no_confirm, dry_run)?;
 

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -205,6 +205,8 @@ impl ReleaseStep {
             log::Level::Warn,
         )?;
 
+        failed |= !super::verify_rate_limit(&pkgs, &index, dry_run, log::Level::Error)?;
+
         let shared_version = super::find_shared_versions(&pkgs)?;
 
         // STEP 1: Release Confirmation


### PR DESCRIPTION
Not thrilled with erroring but putting in a sleep for 10 minutes would probably make people unhappy.  We can always refine this further.

Fixes #483