### PR TITLE
[RFC] feat: add a way to always update the version in dependent Cargo.tomls

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config {
     pub enable_features: Option<Vec<String>>,
     pub enable_all_features: Option<bool>,
     pub dependent_version: Option<DependentVersion>,
+    pub always_update_version: Option<bool>,
     pub target: Option<String>,
 }
 
@@ -87,6 +88,7 @@ impl Config {
             enable_features: Some(empty.enable_features().to_vec()),
             enable_all_features: Some(empty.enable_all_features()),
             dependent_version: Some(empty.dependent_version()),
+            always_update_version: None,
             target: None,
         }
     }
@@ -172,6 +174,9 @@ impl Config {
         }
         if let Some(dependent_version) = source.dependent_version {
             self.dependent_version = Some(dependent_version);
+        }
+        if let Some(always_update_version) = source.always_update_version {
+            self.always_update_version = Some(always_update_version);
         }
         if let Some(target) = source.target.as_deref() {
             self.target = Some(target.to_owned());
@@ -333,6 +338,10 @@ impl Config {
 
     pub fn dependent_version(&self) -> DependentVersion {
         self.dependent_version.unwrap_or_default()
+    }
+
+    pub fn always_update_version(&self) -> bool {
+        self.always_update_version.unwrap_or_default()
     }
 }
 

--- a/src/steps/version.rs
+++ b/src/steps/version.rs
@@ -279,7 +279,7 @@ pub fn update_dependent_versions(
                 }
             }
             config::DependentVersion::Fix => {
-                if !dep.req.matches(&version.bare_version) {
+                if pkg.config.always_update_version() || !dep.req.matches(&version.bare_version) {
                     let new_req =
                         crate::ops::version::set_requirement(&dep.req, &version.bare_version)?;
                     if let Some(new_req) = new_req {
@@ -297,6 +297,15 @@ pub fn update_dependent_versions(
                             dry_run,
                         )?;
                     }
+                } else {
+                    log::debug!(
+                        "Not updating {}'s dependency on {} from `{}` \
+                        because it already matches new version `{}`",
+                        dep.pkg.name,
+                        pkg.meta.name,
+                        dep.req,
+                        version.bare_version,
+                    );
                 }
             }
             config::DependentVersion::Upgrade => {


### PR DESCRIPTION
In workspaces with independent versioning, it can be very useful to always keep dependencies on the latest version even if they're still compatible with the old version. Add a config `always-update-version` that, if set to true, always updates the version in dependent crates.

Looking for feedback on:

* [ ] Is this desirable for cargo-release? I know nextest needs this.
* [ ] What should the name of the option be? I just threw in a name as a placeholder.
* [ ] How should I test this? I noticed that `src/steps/version.rs` doesn't have any tests.