### PR TITLE
fix: Show dirty causes by default 

### DIFF
--- a/src/ops/git.rs
+++ b/src/ops/git.rs
@@ -223,13 +223,11 @@ pub fn push<'s>(
 }
 
 pub fn top_level(dir: &Path) -> CargoResult<PathBuf> {
-    let output = Command::new("git")
-        .arg("rev-parse")
-        .arg("--show-toplevel")
-        .current_dir(dir)
-        .output()?;
-    let path = std::str::from_utf8(&output.stdout)?.trim_end();
-    Ok(Path::new(path).to_owned())
+    let repo = git2::Repository::discover(dir)?;
+
+    repo.workdir()
+        .map(|p| p.to_owned())
+        .ok_or_else(|| anyhow::format_err!("bare repos are unsupported"))
 }
 
 pub fn git_version() -> CargoResult<()> {

--- a/src/ops/git.rs
+++ b/src/ops/git.rs
@@ -80,35 +80,35 @@ pub fn current_branch(dir: &Path) -> CargoResult<String> {
     Ok(name.to_owned())
 }
 
-pub fn is_dirty(dir: &Path) -> CargoResult<bool> {
-    let output = Command::new("git")
-        .arg("diff")
-        .arg("HEAD")
-        .arg("--exit-code")
-        .arg("--name-only")
-        .arg("--")
-        .arg(".")
-        .current_dir(dir)
-        .output()?;
-    let tracked_unclean = !output.status.success();
-    if tracked_unclean {
-        let tracked = String::from_utf8_lossy(&output.stdout);
-        log::debug!("Dirty because of:\n{}", tracked.trim());
+pub fn is_dirty(dir: &Path) -> CargoResult<Option<Vec<String>>> {
+    let repo = git2::Repository::discover(dir)?;
+
+    let mut entries = Vec::new();
+
+    let state = repo.state();
+    let dirty_state = state != git2::RepositoryState::Clean;
+    if dirty_state {
+        entries.push(format!("Dirty because of state {:?}", state));
     }
 
-    let output = Command::new("git")
-        .arg("ls-files")
-        .arg("--exclude-standard")
-        .arg("--others")
-        .current_dir(dir)
-        .output()?;
-    let untracked_files = String::from_utf8_lossy(&output.stdout);
-    let untracked = !untracked_files.as_ref().trim().is_empty();
-    if untracked {
-        log::debug!("Dirty because of:\n{}", untracked_files.trim());
+    let mut options = git2::StatusOptions::new();
+    options
+        .show(git2::StatusShow::IndexAndWorkdir)
+        .include_untracked(true);
+    let statuses = repo.statuses(Some(&mut options))?;
+    let dirty_tree = !statuses.is_empty();
+    if dirty_tree {
+        for status in statuses.iter() {
+            let path = bytes2path(status.path_bytes());
+            entries.push(format!("{} ({:?})", path.display(), status.status()));
+        }
     }
 
-    Ok(tracked_unclean || untracked)
+    if entries.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(entries))
+    }
 }
 
 pub fn changed_files(dir: &Path, tag: &str) -> CargoResult<Option<Vec<PathBuf>>> {
@@ -238,4 +238,18 @@ pub fn git_version() -> CargoResult<()> {
         .output()
         .map(|_| ())
         .map_err(|_| anyhow::format_err!("`git` not found"))
+}
+
+// From git2 crate
+#[cfg(unix)]
+fn bytes2path(b: &[u8]) -> &std::path::Path {
+    use std::os::unix::prelude::*;
+    std::path::Path::new(std::ffi::OsStr::from_bytes(b))
+}
+
+// From git2 crate
+#[cfg(windows)]
+fn bytes2path(b: &[u8]) -> &std::path::Path {
+    use std::str;
+    std::path::Path::new(str::from_utf8(b).unwrap())
 }

--- a/src/steps/commit.rs
+++ b/src/steps/commit.rs
@@ -56,7 +56,7 @@ impl CommitStep {
             .into_iter()
             .map(|(_, pkg)| pkg)
             .partition(|p| p.config.release());
-        if !crate::ops::git::is_dirty(ws_meta.workspace_root.as_std_path())? {
+        if crate::ops::git::is_dirty(ws_meta.workspace_root.as_std_path())?.is_none() {
             log::info!("Nothing to commit.");
             return Err(2.into());
         }

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -21,10 +21,11 @@ pub fn verify_git_is_clean(
     level: log::Level,
 ) -> Result<bool, crate::error::CliError> {
     let mut success = true;
-    if crate::ops::git::is_dirty(path)? {
+    if let Some(dirty) = crate::ops::git::is_dirty(path)? {
         log::log!(
             level,
-            "Uncommitted changes detected, please commit before release."
+            "Uncommitted changes detected, please resolve before release:\n  {}",
+            dirty.join("\n  ")
         );
         if level == log::Level::Error {
             success = false;


### PR DESCRIPTION
This also caused a rewrite of how we detect dirty trees.  I'm assuming
this resolves #195

Fixes #195