### PR TITLE
Revert "fix(config)!: Turn off release with `package.publish = false`"

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -140,11 +140,8 @@ Workspace configuration is read from the following (in precedence order)
 | `target`       | \-              | string                      | \-            | Target triple to use for the verification build |
 | `dependent-version` | \-         | `upgrade`, `fix`, `error`, `warn`, `ignore` | `upgrade`      | Policy for upgrading path dependency versions within the workspace |
 
-Note: fields are from the package-configuration unless otherwise specified.
 
-Note:
-[`package.publish`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field)
-is interpreted the same as `release = false`
+Note: fields are from the package-configuration unless otherwise specified.
 
 ### Supported Environment Variables
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -835,7 +835,6 @@ pub fn resolve_overrides(workspace_root: &Path, manifest_path: &Path) -> CargoRe
             None => true,
         };
         if !publish {
-            release_config.release = Some(false);
             release_config.publish = Some(false);
         }
         if package


### PR DESCRIPTION
This reverts commit b35b462dfc4048a6d4a102e14cef66cba0091bf4.

The decision on #399 (implemented in #544) was a mistake.  We still need to allow people to release and now they need to know to force a release=true once we actually implement support for that.  The inconsistent behavior and implementation complexity do not seem worth it.

Fixes #583