### PR TITLE
fix: Take the --unpublished option into account

### DIFF
--- a/src/steps/hook.rs
+++ b/src/steps/hook.rs
@@ -72,7 +72,11 @@ impl HookStep {
             let explicitly_excluded = self.workspace.exclude.contains(&excluded_pkg.name);
             // 1. Don't show this message if already not releasing in config
             // 2. Still respect `--exclude`
-            if pkg.config.release() && pkg.config.publish() && !explicitly_excluded {
+            if pkg.config.release()
+                && pkg.config.publish()
+                && self.unpublished
+                && !explicitly_excluded
+            {
                 let version = &pkg.initial_version;
                 if !crate::ops::cargo::is_published(
                     &index,

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -87,7 +87,11 @@ impl ReleaseStep {
             let explicitly_excluded = self.workspace.exclude.contains(&excluded_pkg.name);
             // 1. Don't show this message if already not releasing in config
             // 2. Still respect `--exclude`
-            if pkg.config.release() && pkg.config.publish() && !explicitly_excluded {
+            if pkg.config.release()
+                && pkg.config.publish()
+                && self.unpublished
+                && !explicitly_excluded
+            {
                 let version = &pkg.initial_version;
                 if !cargo::is_published(&index, crate_name, &version.full_version_string) {
                     log::debug!(

--- a/src/steps/replace.rs
+++ b/src/steps/replace.rs
@@ -68,7 +68,11 @@ impl ReplaceStep {
             let explicitly_excluded = self.workspace.exclude.contains(&excluded_pkg.name);
             // 1. Don't show this message if already not releasing in config
             // 2. Still respect `--exclude`
-            if pkg.config.release() && pkg.config.publish() && !explicitly_excluded {
+            if pkg.config.release()
+                && pkg.config.publish()
+                && self.unpublished
+                && !explicitly_excluded
+            {
                 let version = &pkg.initial_version;
                 if !crate::ops::cargo::is_published(
                     &index,


### PR DESCRIPTION
https://github.com/crate-ci/cargo-release/commit/11eab502414c3a0040466ac7fa7089e80a836eb1 added support for --unpublished but accidentally always turned it on