### PR TITLE
fix(cli): properly log replacements

### DIFF
--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -80,6 +80,7 @@ pub fn do_file_replacements(
 
     for (path, replaces) in by_file.into_iter() {
         let file = cwd.join(&path);
+        log::debug!("processing replacements for file {}", file.display());
         if !file.exists() {
             anyhow::bail!("unable to find file {} to perform replace", file.display());
         }
@@ -100,15 +101,17 @@ pub fn do_file_replacements(
             let actual = r.find_iter(&replaced).count();
             if actual < min {
                 anyhow::bail!(
-                    "for `{}`, at least {} replacements expected, found {}",
+                    "for `{}` in '{}', at least {} replacements expected, found {}",
                     pattern,
+                    path.display(),
                     min,
                     actual
                 );
             } else if max < actual {
                 anyhow::bail!(
-                    "for `{}`, at most {} replacements expected, found {}",
+                    "for `{}` in '{}', at most {} replacements expected, found {}",
                     pattern,
+                    path.display(),
                     max,
                     actual
                 );


### PR DESCRIPTION
The replacement was not properly logged, making it nearly impossible to figure out in which file a replacement failed, even with trace logging.

To help with that, add a debug message with the full path of the file where replacements are going to be tried in and in case replacement fails, log the file path given in the config.