### PR TITLE
fix: Allow '--dry-run' even though its the default

### DIFF
--- a/src/steps/commit.rs
+++ b/src/steps/commit.rs
@@ -28,6 +28,9 @@ pub struct CommitStep {
     #[arg(short = 'x', long)]
     execute: bool,
 
+    #[arg(short = 'n', long, conflicts_with = "execute", hide = true)]
+    dry_run: bool,
+
     /// Skip release confirmation and version preview
     #[arg(long)]
     no_confirm: bool,
@@ -39,6 +42,11 @@ pub struct CommitStep {
 impl CommitStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
+
+        if self.dry_run {
+            let _ =
+                crate::ops::shell::warn("`--dry-run` is superfluous, dry-run is done by default");
+        }
 
         let ws_meta = self
             .manifest

--- a/src/steps/hook.rs
+++ b/src/steps/hook.rs
@@ -36,6 +36,9 @@ pub struct HookStep {
     #[arg(short = 'x', long)]
     execute: bool,
 
+    #[arg(short = 'n', long, conflicts_with = "execute", hide = true)]
+    dry_run: bool,
+
     /// Skip release confirmation and version preview
     #[arg(long)]
     no_confirm: bool,
@@ -45,6 +48,11 @@ impl HookStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
         let index = crates_index::Index::new_cargo_default()?;
+
+        if self.dry_run {
+            let _ =
+                crate::ops::shell::warn("`--dry-run` is superfluous, dry-run is done by default");
+        }
 
         let ws_meta = self
             .manifest

--- a/src/steps/owner.rs
+++ b/src/steps/owner.rs
@@ -27,6 +27,9 @@ pub struct OwnerStep {
     #[arg(short = 'x', long)]
     execute: bool,
 
+    #[arg(short = 'n', long, conflicts_with = "execute", hide = true)]
+    dry_run: bool,
+
     /// Skip release confirmation and version preview
     #[arg(long)]
     no_confirm: bool,
@@ -35,6 +38,11 @@ pub struct OwnerStep {
 impl OwnerStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
+
+        if self.dry_run {
+            let _ =
+                crate::ops::shell::warn("`--dry-run` is superfluous, dry-run is done by default");
+        }
 
         let ws_meta = self
             .manifest

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -29,6 +29,9 @@ pub struct PublishStep {
     #[arg(short = 'x', long)]
     execute: bool,
 
+    #[arg(short = 'n', long, conflicts_with = "execute", hide = true)]
+    dry_run: bool,
+
     /// Skip release confirmation and version preview
     #[arg(long)]
     no_confirm: bool,
@@ -40,6 +43,11 @@ pub struct PublishStep {
 impl PublishStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
+
+        if self.dry_run {
+            let _ =
+                crate::ops::shell::warn("`--dry-run` is superfluous, dry-run is done by default");
+        }
 
         let ws_meta = self
             .manifest

--- a/src/steps/push.rs
+++ b/src/steps/push.rs
@@ -29,6 +29,9 @@ pub struct PushStep {
     #[arg(short = 'x', long)]
     execute: bool,
 
+    #[arg(short = 'n', long, conflicts_with = "execute", hide = true)]
+    dry_run: bool,
+
     /// Skip release confirmation and version preview
     #[arg(long)]
     no_confirm: bool,
@@ -43,6 +46,11 @@ pub struct PushStep {
 impl PushStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
+
+        if self.dry_run {
+            let _ =
+                crate::ops::shell::warn("`--dry-run` is superfluous, dry-run is done by default");
+        }
 
         let ws_meta = self
             .manifest

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -28,6 +28,9 @@ pub struct ReleaseStep {
     #[arg(short = 'x', long)]
     execute: bool,
 
+    #[arg(short = 'n', long, conflicts_with = "execute", hide = true)]
+    dry_run: bool,
+
     /// Skip release confirmation and version preview
     #[arg(long)]
     no_confirm: bool,
@@ -44,6 +47,11 @@ impl ReleaseStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
         let mut index = crates_index::Index::new_cargo_default()?;
+
+        if self.dry_run {
+            let _ =
+                crate::ops::shell::warn("`--dry-run` is superfluous, dry-run is done by default");
+        }
 
         let ws_meta = self
             .manifest

--- a/src/steps/replace.rs
+++ b/src/steps/replace.rs
@@ -32,6 +32,9 @@ pub struct ReplaceStep {
     #[arg(short = 'x', long)]
     execute: bool,
 
+    #[arg(short = 'n', long, conflicts_with = "execute", hide = true)]
+    dry_run: bool,
+
     /// Skip release confirmation and version preview
     #[arg(long)]
     no_confirm: bool,
@@ -41,6 +44,11 @@ impl ReplaceStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
         let index = crates_index::Index::new_cargo_default()?;
+
+        if self.dry_run {
+            let _ =
+                crate::ops::shell::warn("`--dry-run` is superfluous, dry-run is done by default");
+        }
 
         let ws_meta = self
             .manifest

--- a/src/steps/tag.rs
+++ b/src/steps/tag.rs
@@ -33,6 +33,9 @@ pub struct TagStep {
     #[arg(short = 'x', long)]
     execute: bool,
 
+    #[arg(short = 'n', long, conflicts_with = "execute", hide = true)]
+    dry_run: bool,
+
     /// Skip release confirmation and version preview
     #[arg(long)]
     no_confirm: bool,
@@ -44,6 +47,11 @@ pub struct TagStep {
 impl TagStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
+
+        if self.dry_run {
+            let _ =
+                crate::ops::shell::warn("`--dry-run` is superfluous, dry-run is done by default");
+        }
 
         let ws_meta = self
             .manifest

--- a/src/steps/version.rs
+++ b/src/steps/version.rs
@@ -28,6 +28,9 @@ pub struct VersionStep {
     #[arg(short = 'x', long)]
     execute: bool,
 
+    #[arg(short = 'n', long, conflicts_with = "execute", hide = true)]
+    dry_run: bool,
+
     /// Skip release confirmation and version preview
     #[arg(long)]
     no_confirm: bool,
@@ -48,6 +51,11 @@ pub struct VersionStep {
 impl VersionStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
+
+        if self.dry_run {
+            let _ =
+                crate::ops::shell::warn("`--dry-run` is superfluous, dry-run is done by default");
+        }
 
         let ws_meta = self
             .manifest


### PR DESCRIPTION
I found I ended up doing this and was confused until I looked at the source code.  This seems a friendly way to guide users into what needs to happen.