### PR TITLE
docs(ref): Remove reference to removed feature

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -145,7 +145,7 @@ Note: fields are from the package-configuration unless otherwise specified.
 
 * `PUBLISH_GRACE_SLEEP`: sleep timeout between crates publish when releasing from workspace. This is a workaround to make previous crate discoverable on crates.io.
 
-### {Pre,Post}-release Replacements
+### Pre-release Replacements
 
 This field is an array of tables with the following
 


### PR DESCRIPTION
`post-release-replacements` was removed in [PR #553][], and most of its documentation was removed in [PR #600][]. This removes the last reference to it.

Fixes #630

[PR #553]: https://github.com/crate-ci/cargo-release/pull/553
[PR #600]: https://github.com/crate-ci/cargo-release/pull/600