### PR TITLE
Enable feature "vendored-openssl" on dependency git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ pre-release-replacements = [
 cargo_metadata = "0.15"
 crates-index = "0.19"
 # Enabling the feature for `crates-index`
-git2 = { version = "0.16.1", features = ["vendored-libgit2"], default-features = false }
+git2 = { version = "0.16.1", features = ["vendored-libgit2", "vendored-openssl"], default-features = false }
 toml_edit = "0.19.6"
 toml = "0.7.3"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
so that `cargo-release` can build in environment where openssl isn't installed or hard to install (e.g. cross compilation) and the binaries built can be run on everywhere, without runtime dependencies.