### PR TITLE
fix(index): Don't talk to crates.io when using alt registry

### DIFF
--- a/src/steps/hook.rs
+++ b/src/steps/hook.rs
@@ -47,7 +47,7 @@ pub struct HookStep {
 impl HookStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
-        let mut index = crate::ops::index::CratesIoIndex::open()?;
+        let mut index = crate::ops::index::CratesIoIndex::new();
 
         if self.dry_run {
             let _ =

--- a/src/steps/hook.rs
+++ b/src/steps/hook.rs
@@ -88,6 +88,7 @@ impl HookStep {
                 let version = &pkg.initial_version;
                 if !crate::ops::cargo::is_published(
                     &mut index,
+                    pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,
                 ) {

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -225,9 +225,10 @@ pub fn verify_rate_limit(
     let mut new = 0;
     let mut existing = 0;
     for pkg in pkgs {
+        // Note: these rate limits are only known for default registry
         if pkg.config.registry().is_none() && pkg.config.publish() {
             let crate_name = pkg.meta.name.as_str();
-            if index.has_krate(crate_name)? {
+            if index.has_krate(None, crate_name)? {
                 existing += 1;
             } else {
                 new += 1;

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -80,7 +80,7 @@ impl PublishStep {
 
         let mut pkgs = plan::plan(pkgs)?;
 
-        let mut index = crate::ops::index::CratesIoIndex::open()?;
+        let mut index = crate::ops::index::CratesIoIndex::new();
         for pkg in pkgs.values_mut() {
             if pkg.config.registry().is_none() && pkg.config.release() {
                 let crate_name = pkg.meta.name.as_str();

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -82,11 +82,12 @@ impl PublishStep {
 
         let mut index = crate::ops::index::CratesIoIndex::new();
         for pkg in pkgs.values_mut() {
-            if pkg.config.registry().is_none() && pkg.config.release() {
+            if pkg.config.release() {
                 let crate_name = pkg.meta.name.as_str();
                 let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
                 if crate::ops::cargo::is_published(
                     &mut index,
+                    pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,
                 ) {
@@ -200,33 +201,31 @@ pub fn publish(
             return Err(101.into());
         }
 
-        if pkg.config.registry().is_none() {
-            let timeout = std::time::Duration::from_secs(300);
-            let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
-            crate::ops::cargo::wait_for_publish(
-                index,
-                crate_name,
-                &version.full_version_string,
-                timeout,
-                dry_run,
-            )?;
-            // HACK: Even once the index is updated, there seems to be another step before the publish is fully ready.
-            // We don't have a way yet to check for that, so waiting for now in hopes everything is ready
-            if !dry_run {
-                let publish_grace_sleep = std::env::var("PUBLISH_GRACE_SLEEP")
-                    .unwrap_or_else(|_| Default::default())
-                    .parse()
-                    .unwrap_or(0);
-                if 0 < publish_grace_sleep {
-                    log::debug!(
-                        "waiting an additional {} seconds for crates.io to update its indices...",
-                        publish_grace_sleep
-                    );
-                    std::thread::sleep(std::time::Duration::from_secs(publish_grace_sleep));
-                }
+        let timeout = std::time::Duration::from_secs(300);
+        let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
+        crate::ops::cargo::wait_for_publish(
+            index,
+            pkg.config.registry(),
+            crate_name,
+            &version.full_version_string,
+            timeout,
+            dry_run,
+        )?;
+        // HACK: Even once the index is updated, there seems to be another step before the publish is fully ready.
+        // We don't have a way yet to check for that, so waiting for now in hopes everything is ready
+        if !dry_run {
+            let publish_grace_sleep = std::env::var("PUBLISH_GRACE_SLEEP")
+                .unwrap_or_else(|_| Default::default())
+                .parse()
+                .unwrap_or(0);
+            if 0 < publish_grace_sleep {
+                log::debug!(
+                    "waiting an additional {} seconds for {} to update its indices...",
+                    publish_grace_sleep,
+                    pkg.config.registry().unwrap_or("crates.io")
+                );
+                std::thread::sleep(std::time::Duration::from_secs(publish_grace_sleep));
             }
-        } else {
-            log::debug!("not waiting for publish because the registry is not crates.io and doesn't get updated automatically");
         }
     }
 

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -46,7 +46,7 @@ pub struct ReleaseStep {
 impl ReleaseStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
-        let mut index = crate::ops::index::CratesIoIndex::open()?;
+        let mut index = crate::ops::index::CratesIoIndex::new();
 
         if self.dry_run {
             let _ =

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -73,7 +73,7 @@ impl ReleaseStep {
                     pkg.bump(level_or_version, self.metadata.as_deref())?;
                 }
             }
-            if index.has_krate(&pkg.meta.name)? {
+            if index.has_krate(pkg.config.registry(), &pkg.meta.name)? {
                 // Already published, skip it.  Use `cargo release owner` for one-time updates
                 pkg.ensure_owners = false;
             }
@@ -101,7 +101,12 @@ impl ReleaseStep {
                 && !explicitly_excluded
             {
                 let version = &pkg.initial_version;
-                if !cargo::is_published(&mut index, crate_name, &version.full_version_string) {
+                if !cargo::is_published(
+                    &mut index,
+                    pkg.config.registry(),
+                    crate_name,
+                    &version.full_version_string,
+                ) {
                     log::debug!(
                         "enabled {}, v{} is unpublished",
                         crate_name,
@@ -152,10 +157,16 @@ impl ReleaseStep {
                 continue;
             };
 
+            // HACK: `index` only supports default registry
             if pkg.config.publish() && pkg.config.registry().is_none() {
                 let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
                 let crate_name = pkg.meta.name.as_str();
-                if !cargo::is_published(&mut index, crate_name, &version.full_version_string) {
+                if !cargo::is_published(
+                    &mut index,
+                    pkg.config.registry(),
+                    crate_name,
+                    &version.full_version_string,
+                ) {
                     let _ = crate::ops::shell::warn(format!(
                         "disabled by user, skipping {} v{} despite being unpublished",
                         crate_name, version.full_version_string,
@@ -195,16 +206,19 @@ impl ReleaseStep {
             if !pkg.config.publish() {
                 continue;
             }
-            if pkg.config.registry().is_none() {
-                let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
-                let crate_name = pkg.meta.name.as_str();
-                if cargo::is_published(&mut index, crate_name, &version.full_version_string) {
-                    let _ = crate::ops::shell::error(format!(
-                        "{} {} is already published",
-                        crate_name, version.full_version_string
-                    ));
-                    double_publish = true;
-                }
+            let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
+            let crate_name = pkg.meta.name.as_str();
+            if cargo::is_published(
+                &mut index,
+                pkg.config.registry(),
+                crate_name,
+                &version.full_version_string,
+            ) {
+                let _ = crate::ops::shell::error(format!(
+                    "{} {} is already published",
+                    crate_name, version.full_version_string
+                ));
+                double_publish = true;
             }
         }
         if double_publish {

--- a/src/steps/replace.rs
+++ b/src/steps/replace.rs
@@ -84,6 +84,7 @@ impl ReplaceStep {
                 let version = &pkg.initial_version;
                 if !crate::ops::cargo::is_published(
                     &mut index,
+                    pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,
                 ) {

--- a/src/steps/replace.rs
+++ b/src/steps/replace.rs
@@ -43,7 +43,7 @@ pub struct ReplaceStep {
 impl ReplaceStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
-        let mut index = crate::ops::index::CratesIoIndex::open()?;
+        let mut index = crate::ops::index::CratesIoIndex::new();
 
         if self.dry_run {
             let _ =


### PR DESCRIPTION
Ideally we'd find the proper registry and talk to it but that takes a
lot more work to support.
Until then, we'll just act like the registry has no packages in it and
put in some specific hacks to support it.

This should be less brittle than our previous approach which just hoped
we sprinkled `config.registr().is_none()` in the right places.


Fixes #732