### PR TITLE
feat: Don't release packages without a version

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -864,6 +864,11 @@ pub fn resolve_overrides(workspace_root: &Path, manifest_path: &Path) -> CargoRe
         if !publish {
             release_config.publish = Some(false);
         }
+
+        if package.version.is_none() {
+            // No point releasing if it can't be published and doesn't have a version to update
+            release_config.release = Some(false);
+        }
         if package
             .version
             .as_ref()


### PR DESCRIPTION
As of Rust 1.75, `Cargo.toml` doesn't have to have a version field.  When its missing, the package version is treated as `0.0.0` and it can't be published.

In support of that, we disallowing packages from being released when they lack a version.  There is nothing to publish and no version to bump, so nothing that can be done. 

For all other cases, we should work just fine because we read the version from `cargo metadata` which will be `0.0.0`.