### PR TITLE
Fix incorrect verbiage in the 'downgrade' error message

### DIFF
--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -193,7 +193,7 @@ pub fn verify_monotonically_increasing(
                 let _ = crate::ops::shell::log(
                     level,
                     format!(
-                        "cannot downgrade {} from {} to {}",
+                        "cannot downgrade {} to {} from {}",
                         crate_name, version.full_version, pkg.initial_version.full_version
                     ),
                 );


### PR DESCRIPTION
When attempting to downgrade a package on release, the error message is helpful but looks like it presents versions in the incorrect order:

```
$ cargo release 0.2.0
error: tag `v0.2.0` already exists (for `mypackage`)
error: cannot downgrade mypackage from 0.2.0 to 0.3.0
```