### PR TITLE
Use similar rather than difflib to get better diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,6 @@ dependencies = [
  "clap",
  "clap-cargo",
  "concolor-control",
- "difflib",
  "dirs-next",
  "dunce",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "reqwest",
  "semver",
  "serde",
+ "similar",
  "snapbox",
  "tame-index",
  "termcolor",
@@ -1950,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.2.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ trycmd = "0.14.21"
 anyhow = "1.0.79"
 concolor-control = { version = "0.0.7", features = ["auto"] }
 git-conventional = "0.12.4"
+similar = "2.4"
 
 [dev-dependencies]
 assert_fs = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ indexmap = "2.2"
 time = { version = "0.3", features = ["formatting", "macros"] }
 dirs-next = "2.0"
 ignore = "0.4"
-difflib = "0.4"
 itertools = "0.12"
 once_cell = "1.19.0"
 clap = { version = "4.4.18", features = ["derive", "wrap_help"] }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,14 @@
+use std::path::Path;
+
+use similar::TextDiff;
+
+pub(crate) fn unified_diff(old: &str, new: &str, path: &Path, new_description: &str) -> String {
+    let diff = TextDiff::from_lines(old, new);
+    let path = path.display();
+    diff.unified_diff()
+        .header(
+            &format!("{path}\toriginal"),
+            &format!("{path}\t{new_description}"),
+        )
+        .to_string()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod config;
+mod diff;
 pub mod error;
 pub mod ops;
 pub mod shell;

--- a/src/ops/cargo.rs
+++ b/src/ops/cargo.rs
@@ -180,22 +180,9 @@ pub fn set_workspace_version(
 
     if dry_run {
         if manifest != original_manifest {
-            let display_path = manifest_path.display().to_string();
-            let old_lines: Vec<_> = original_manifest
-                .lines()
-                .map(|s| format!("{}\n", s))
-                .collect();
-            let new_lines: Vec<_> = manifest.lines().map(|s| format!("{}\n", s)).collect();
-            let diff = difflib::unified_diff(
-                &old_lines,
-                &new_lines,
-                display_path.as_str(),
-                display_path.as_str(),
-                "original",
-                "updated",
-                0,
-            );
-            log::debug!("change:\n{}", itertools::join(diff.into_iter(), ""));
+            let diff =
+                crate::diff::unified_diff(&original_manifest, &manifest, manifest_path, "updated");
+            log::debug!("change:\n{diff}");
         }
     } else {
         atomic_write(manifest_path, &manifest)?;
@@ -291,22 +278,9 @@ pub fn set_package_version(manifest_path: &Path, version: &str, dry_run: bool) -
 
     if dry_run {
         if manifest != original_manifest {
-            let display_path = manifest_path.display().to_string();
-            let old_lines: Vec<_> = original_manifest
-                .lines()
-                .map(|s| format!("{}\n", s))
-                .collect();
-            let new_lines: Vec<_> = manifest.lines().map(|s| format!("{}\n", s)).collect();
-            let diff = difflib::unified_diff(
-                &old_lines,
-                &new_lines,
-                display_path.as_str(),
-                display_path.as_str(),
-                "original",
-                "updated",
-                0,
-            );
-            log::debug!("change:\n{}", itertools::join(diff.into_iter(), ""));
+            let diff =
+                crate::diff::unified_diff(&original_manifest, &manifest, manifest_path, "updated");
+            log::debug!("change:\n{diff}");
         }
     } else {
         atomic_write(manifest_path, &manifest)?;
@@ -340,22 +314,9 @@ pub fn upgrade_dependency_req(
     let manifest = manifest.to_string();
     if manifest != original_manifest {
         if dry_run {
-            let display_path = manifest_path.display().to_string();
-            let old_lines: Vec<_> = original_manifest
-                .lines()
-                .map(|s| format!("{}\n", s))
-                .collect();
-            let new_lines: Vec<_> = manifest.lines().map(|s| format!("{}\n", s)).collect();
-            let diff = difflib::unified_diff(
-                &old_lines,
-                &new_lines,
-                display_path.as_str(),
-                display_path.as_str(),
-                "original",
-                "updated",
-                0,
-            );
-            log::debug!("change:\n{}", itertools::join(diff.into_iter(), ""));
+            let diff =
+                crate::diff::unified_diff(&original_manifest, &manifest, manifest_path, "updated");
+            log::debug!("change:\n{diff}");
         } else {
             atomic_write(manifest_path, &manifest)?;
         }

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use similar::TextDiff;
-
 use crate::config::Replace;
 use crate::error::CargoResult;
 
@@ -121,14 +119,12 @@ pub fn do_file_replacements(
         if data != replaced {
             if dry_run {
                 if noisy {
-                    let diff = TextDiff::from_lines(&data, &replaced);
-                    let display_path = path.display().to_string();
                     let _ = crate::ops::shell::status(
                         "Replacing",
                         format!(
                             "in {}\n{}",
                             path.display(),
-                            diff.unified_diff().header(&display_path, &display_path)
+                            crate::diff::unified_diff(&data, &replaced, &path, "replaced")
                         ),
                     );
                 } else {


### PR DESCRIPTION
Gives much better diffs when lines are inserted

Fixes #755

After:

```
   Replacing in NEWS.md
--- NEWS.md
+++ NEWS.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 24.2.1
+
 - New: `--features`, `--no-default-features` and `--all-features` options are passed through to Cargo.
 
 - Changed: Minimum Rust version (to build cargo-mutants, not to use it) increased to 1.73.
```

If this is OK in principal I can update all the other call sites that use difflib.