### PR TITLE
Enable selecting system certificate stores.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -1758,16 +1759,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1804,6 +1806,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
@@ -1872,6 +1887,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2120,9 +2158,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tame-index"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c09360f6b03266a73e111665451a8a1cec970eb58fc394f84a20cb3e6325f766"
+checksum = "44a98d58caab3de29c6cb538054c7d994b3d7e6eec483a9dfca02f92027f7686"
 dependencies = [
  "camino",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,12 @@ vendored-openssl = ["git2/vendored-openssl"]
 
 [dependencies]
 cargo_metadata = "0.18"
-tame-index = { version = "0.11", features = ["sparse"] }
+# Use this with default-features set to "true" (implicitly) so that reqwest,
+# a transitive dependency, is compiled with support for both webpki
+# certificates AND native certificates. We want support for both to be
+# present, and then to let the user _select_ through configuration which
+# one they want to be used.
+tame-index = { version = "0.11", features = ["sparse", "native-certs"] }
 git2 = { version = "0.18.3", default-features = false }
 toml_edit = { version = "0.22.12", features = ["serde"] }
 toml = "0.8.12"

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,25 +27,27 @@ Arguments:
                    values: major, minor, patch, release, rc, beta, alpha]
 
 Options:
-      --manifest-path <PATH>        Path to Cargo.toml
-  -p, --package <SPEC>              Package to process (see `cargo help pkgid`)
-      --workspace                   Process all packages in the workspace
-      --exclude <SPEC>              Exclude packages from being processed
-      --unpublished                 Process all packages whose current version is unpublished
-  -m, --metadata <METADATA>         Semver metadata
-  -x, --execute                     Actually perform a release. Dry-run mode is the default
-      --no-confirm                  Skip release confirmation and version preview
-      --prev-tag-name <NAME>        The name of tag for the previous release
-  -c, --config <PATH>               Custom config file
-      --isolated                    Ignore implicit configuration files
-      --sign                        Sign both git commit and tag
-      --dependent-version <ACTION>  Specify how workspace dependencies on this crate should be
-                                    handed [possible values: upgrade, fix]
-      --allow-branch <GLOB[,...]>   Comma-separated globs of branch names a release can happen from
-  -q, --quiet...                    Pass many times for less log output
-  -v, --verbose...                  Pass many times for more log output
-  -h, --help                        Print help (see more with '--help')
-  -V, --version                     Print version
+      --manifest-path <PATH>         Path to Cargo.toml
+  -p, --package <SPEC>               Package to process (see `cargo help pkgid`)
+      --workspace                    Process all packages in the workspace
+      --exclude <SPEC>               Exclude packages from being processed
+      --unpublished                  Process all packages whose current version is unpublished
+  -m, --metadata <METADATA>          Semver metadata
+  -x, --execute                      Actually perform a release. Dry-run mode is the default
+      --no-confirm                   Skip release confirmation and version preview
+      --prev-tag-name <NAME>         The name of tag for the previous release
+  -c, --config <PATH>                Custom config file
+      --isolated                     Ignore implicit configuration files
+      --sign                         Sign both git commit and tag
+      --dependent-version <ACTION>   Specify how workspace dependencies on this crate should be
+                                     handed [possible values: upgrade, fix]
+      --allow-branch <GLOB[,...]>    Comma-separated globs of branch names a release can happen from
+      --certs-source <CERTS_SOURCE>  Indicate what certificate store to use for web requests
+                                     [possible values: webpki, native]
+  -q, --quiet...                     Pass many times for less log output
+  -v, --verbose...                   Pass many times for more log output
+  -h, --help                         Print help (see more with '--help')
+  -V, --version                      Print version
 
 Commit:
       --sign-commit  Sign git commit
@@ -140,7 +142,7 @@ Workspace configuration is read from the following (in precedence order)
 | `metadata`     | \-              | `optional`, `required`, `ignore`, `persistent` | `optional` | Policy for presence of absence of `--metadata` flag when changing the version |
 | `rate-limit.new-packages` | \-   | integer                     | `5`           | `optional` | Rate limit for publishing new packages |
 | `rate-limit.existing-packages` | \- | integer                  | `30`          | `optional` | Rate limit for publishing existing packages |
-
+| `certs-source` | \-              | `webpki`, `native`                             | `webpki`   | Policy for using Mozilla's standard certificate root of trust (`webpki`) or using the system certificate root of trust (`native`) |
 
 Note: fields are from the package-configuration unless otherwise specified.
 

--- a/src/steps/hook.rs
+++ b/src/steps/hook.rs
@@ -91,6 +91,7 @@ impl HookStep {
                     pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,
+                    pkg.config.certs_source(),
                 ) {
                     log::debug!(
                         "enabled {}, v{} is unpublished",

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -229,7 +229,7 @@ pub fn verify_rate_limit(
         // Note: these rate limits are only known for default registry
         if pkg.config.registry().is_none() && pkg.config.publish() {
             let crate_name = pkg.meta.name.as_str();
-            if index.has_krate(None, crate_name)? {
+            if index.has_krate(None, crate_name, pkg.config.certs_source())? {
                 existing += 1;
             } else {
                 new += 1;

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -90,6 +90,7 @@ impl PublishStep {
                     pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,
+                    pkg.config.certs_source(),
                 ) {
                     let _ = crate::ops::shell::warn(format!(
                         "disabled due to previous publish ({}), skipping {}",
@@ -215,6 +216,7 @@ pub fn publish(
             &version.full_version_string,
             timeout,
             dry_run,
+            pkg.config.certs_source(),
         )?;
         // HACK: Even once the index is updated, there seems to be another step before the publish is fully ready.
         // We don't have a way yet to check for that, so waiting for now in hopes everything is ready

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -73,7 +73,11 @@ impl ReleaseStep {
                     pkg.bump(level_or_version, self.metadata.as_deref())?;
                 }
             }
-            if index.has_krate(pkg.config.registry(), &pkg.meta.name)? {
+            if index.has_krate(
+                pkg.config.registry(),
+                &pkg.meta.name,
+                pkg.config.certs_source(),
+            )? {
                 // Already published, skip it.  Use `cargo release owner` for one-time updates
                 pkg.ensure_owners = false;
             }
@@ -106,6 +110,7 @@ impl ReleaseStep {
                     pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,
+                    pkg.config.certs_source(),
                 ) {
                     log::debug!(
                         "enabled {}, v{} is unpublished",
@@ -166,6 +171,7 @@ impl ReleaseStep {
                     pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,
+                    pkg.config.certs_source(),
                 ) {
                     let _ = crate::ops::shell::warn(format!(
                         "disabled by user, skipping {} v{} despite being unpublished",
@@ -213,6 +219,7 @@ impl ReleaseStep {
                 pkg.config.registry(),
                 crate_name,
                 &version.full_version_string,
+                pkg.config.certs_source(),
             ) {
                 let _ = crate::ops::shell::error(format!(
                     "{} {} is already published",

--- a/src/steps/replace.rs
+++ b/src/steps/replace.rs
@@ -87,6 +87,7 @@ impl ReplaceStep {
                     pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,
+                    pkg.config.certs_source(),
                 ) {
                     log::debug!(
                         "enabled {}, v{} is unpublished",


### PR DESCRIPTION
This commit adds the ability to select what certificate root store to use when making HTTPS connections. Previously, `cargo-release` was configured to use the default for `tame-index`, which is the "webpki" root of trust maintained by Mozilla. This is a good and reasonable set of certificates, _except_ for users on networks which substitute certificates.

Substituting certificates is something enterprise networks will frequently do so they can man-in-the-middle HTTPS connections made on their network and thus maintain visibility into the network activities of their employees. In this setup, the users' devices will generally be running enterprise-managed software which replaces certificates used by public websites with ones provided by the network software the enterprise uses, with the root certificates for these substituted chains being placed in the users' local system certificate store. In that case, with only the "webpki" certificate store loaded for `cargo-release`, the substituted certificates will fail to validate, and publication of new versions (indeed, even checking publication status of the crate attempting to be published) will fail with an HTTPS error about an untrusted certificate.

The solution chosen here was to add a configuration element, and a CLI flag under the "publish" section, which lets the user pick between "webpki" (Mozilla) or "native" (local system) certificate trust stores. The portion of the code in `src/ops/index.rs` which handles connecting to the registry index has been updated to configure which certificate store to use based on the user's selection.

The one final wrinkle is that we get `reqwest`, the dependency which actually handles HTTPS connections, through the `tame-index` crate, which re-exports it. To enable the APIs in `reqwest` for configuring what TLS certs to pick up, we have to enable the "native-certs" feature on `tame-index`, while leaving the default features on. This is something `tame-index` normally recommends _against_, because it assumes you want to exclusively activate one of them at compile time. In our case, we need the selection to happen at runtime, so we need both to be compiled in.

Fixes #764 