### PR TITLE
feat: support project level `rate_limit`

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -138,8 +138,8 @@ Workspace configuration is read from the following (in precedence order)
 | `target`       | \-              | string                      | \-            | Target triple to use for the verification build |
 | `dependent-version` | \-         | `upgrade`, `fix`, `error`, `warn`, `ignore` | `upgrade`      | Policy for upgrading path dependency versions within the workspace |
 | `metadata`     | \-              | `optional`, `required`, `ignore`, `persistent` | `optional` | Policy for presence of absence of `--metadata` flag when changing the version |
-| `rate-limit.new-packages` | \-   | integer                     | `5`           | `optional` | Rate limit for publishing new packages |
-| `rate-limit.existing-packages` | \- | integer                  | `30`          | `optional` | Rate limit for publishing existing packages |
+| `rate-limit.new-packages` | \-   | positive integer            | `5`           | `optional` | Rate limit for publishing new packages |
+| `rate-limit.existing-packages` | \- | positive integer         | `30`          | `optional` | Rate limit for publishing existing packages |
 
 
 Note: fields are from the package-configuration unless otherwise specified.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -138,7 +138,8 @@ Workspace configuration is read from the following (in precedence order)
 | `target`       | \-              | string                      | \-            | Target triple to use for the verification build |
 | `dependent-version` | \-         | `upgrade`, `fix`, `error`, `warn`, `ignore` | `upgrade`      | Policy for upgrading path dependency versions within the workspace |
 | `metadata`     | \-              | `optional`, `required`, `ignore`, `persistent` | `optional` | Policy for presence of absence of `--metadata` flag when changing the version |
-| `rate-limit`   | \-              | maps of strings to integers | `{ new-packages = 5, existing-packages = 30 }` | `optional` | Rate limits for the release process |
+| `rate-limit.new-packages` | \-   | integer                     | `5`           | `optional` | Rate limit for publishing new packages |
+| `rate-limit.existing-packages` | \- | integer                  | `30`          | `optional` | Rate limit for publishing existing packages |
 
 
 Note: fields are from the package-configuration unless otherwise specified.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -138,6 +138,7 @@ Workspace configuration is read from the following (in precedence order)
 | `target`       | \-              | string                      | \-            | Target triple to use for the verification build |
 | `dependent-version` | \-         | `upgrade`, `fix`, `error`, `warn`, `ignore` | `upgrade`      | Policy for upgrading path dependency versions within the workspace |
 | `metadata`     | \-              | `optional`, `required`, `ignore`, `persistent` | `optional` | Policy for presence of absence of `--metadata` flag when changing the version |
+| `rate-limit`   | \-              | maps of strings to integers | `{ new-packages = 5, existing-packages = 30 }` | `optional` | Rate limits for the release process |
 
 
 Note: fields are from the package-configuration unless otherwise specified.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -138,8 +138,8 @@ Workspace configuration is read from the following (in precedence order)
 | `target`       | \-              | string                      | \-            | Target triple to use for the verification build |
 | `dependent-version` | \-         | `upgrade`, `fix`, `error`, `warn`, `ignore` | `upgrade`      | Policy for upgrading path dependency versions within the workspace |
 | `metadata`     | \-              | `optional`, `required`, `ignore`, `persistent` | `optional` | Policy for presence of absence of `--metadata` flag when changing the version |
-| `rate-limit.new-packages` | \-   | positive integer            | `5`           | `optional` | Rate limit for publishing new packages |
-| `rate-limit.existing-packages` | \- | positive integer         | `30`          | `optional` | Rate limit for publishing existing packages |
+| `rate-limit.new-packages` | \-   | integer                     | `5`           | `optional` | Rate limit for publishing new packages |
+| `rate-limit.existing-packages` | \- | integer                  | `30`          | `optional` | Rate limit for publishing existing packages |
 
 
 Note: fields are from the package-configuration unless otherwise specified.

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,7 +86,7 @@ impl Config {
             dependent_version: Some(empty.dependent_version()),
             metadata: Some(empty.metadata()),
             target: None,
-            rate_limit: empty.rate_limit().clone(),
+            rate_limit: RateLimit::from_defaults(),
         }
     }
 
@@ -303,10 +303,6 @@ impl Config {
     pub fn metadata(&self) -> MetadataPolicy {
         self.metadata.unwrap_or_default()
     }
-
-    pub fn rate_limit(&self) -> &RateLimit {
-        &self.rate_limit
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -460,22 +456,13 @@ struct CargoMetadata {
     release: Option<Config>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct RateLimit {
     #[serde(default)]
-    pub new_packages: usize,
+    pub new_packages: Option<usize>,
     #[serde(default)]
-    pub existing_packages: usize,
-}
-
-impl Default for RateLimit {
-    fn default() -> Self {
-        RateLimit {
-            new_packages: 5,
-            existing_packages: 30,
-        }
-    }
+    pub existing_packages: Option<usize>,
 }
 
 impl RateLimit {
@@ -484,16 +471,27 @@ impl RateLimit {
     }
 
     pub fn from_defaults() -> Self {
-        Self::new()
+        Self {
+            new_packages: Some(5),
+            existing_packages: Some(30),
+        }
     }
 
     pub fn update(&mut self, source: &RateLimit) {
-        if source.new_packages != 0 {
+        if source.new_packages.is_some() {
             self.new_packages = source.new_packages;
         }
-        if source.existing_packages != 0 {
+        if source.existing_packages.is_some() {
             self.existing_packages = source.existing_packages;
         }
+    }
+
+    pub fn new_packages(&self) -> usize {
+        self.new_packages.unwrap_or(5)
+    }
+
+    pub fn existing_packages(&self) -> usize {
+        self.existing_packages.unwrap_or(30)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -463,9 +463,10 @@ struct CargoMetadata {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct RateLimit {
-    pub new: Option<usize>,
-    pub existing: Option<usize>,
+    pub new_packages: Option<usize>,
+    pub existing_packages: Option<usize>,
 }
 
 pub fn load_workspace_config(

--- a/src/config.rs
+++ b/src/config.rs
@@ -460,7 +460,7 @@ struct CargoMetadata {
     release: Option<Config>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct RateLimit {
     #[serde(default)]
@@ -469,16 +469,22 @@ pub struct RateLimit {
     pub existing_packages: usize,
 }
 
+impl Default for RateLimit {
+    fn default() -> Self {
+        RateLimit {
+            new_packages: 5,
+            existing_packages: 30,
+        }
+    }
+}
+
 impl RateLimit {
     pub fn new() -> Self {
         Default::default()
     }
 
     pub fn from_defaults() -> Self {
-        RateLimit {
-            new_packages: 5,
-            existing_packages: 30,
-        }
+        Self::new()
     }
 
     pub fn update(&mut self, source: &RateLimit) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,7 +86,10 @@ impl Config {
             dependent_version: Some(empty.dependent_version()),
             metadata: Some(empty.metadata()),
             target: None,
-            rate_limit: None,
+            rate_limit: Some(RateLimit {
+                new_packages: Some(empty.rate_limit_for_new_packages()),
+                existing_packages: Some(empty.rate_limit_for_existing_packages()),
+            }),
         }
     }
 
@@ -308,6 +311,14 @@ impl Config {
 
     pub fn rate_limit(&self) -> RateLimit {
         self.rate_limit.clone().unwrap_or_default()
+    }
+
+    pub fn rate_limit_for_new_packages(&self) -> usize {
+        self.rate_limit().new_packages.unwrap_or(5)
+    }
+
+    pub fn rate_limit_for_existing_packages(&self) -> usize {
+        self.rate_limit().existing_packages.unwrap_or(30)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ pub struct Config {
     pub dependent_version: Option<DependentVersion>,
     pub metadata: Option<MetadataPolicy>,
     pub target: Option<String>,
+    pub rate_limit: Option<RateLimit>,
 }
 
 impl Config {
@@ -85,6 +86,7 @@ impl Config {
             dependent_version: Some(empty.dependent_version()),
             metadata: Some(empty.metadata()),
             target: None,
+            rate_limit: None,
         }
     }
 
@@ -163,6 +165,10 @@ impl Config {
         }
         if let Some(target) = source.target.as_deref() {
             self.target = Some(target.to_owned());
+        }
+
+        if let Some(rate_limit) = source.rate_limit.as_ref() {
+            self.rate_limit = Some(rate_limit.to_owned());
         }
     }
 
@@ -298,6 +304,10 @@ impl Config {
 
     pub fn metadata(&self) -> MetadataPolicy {
         self.metadata.unwrap_or_default()
+    }
+
+    pub fn rate_limit(&self) -> RateLimit {
+        self.rate_limit.clone().unwrap_or_default()
     }
 }
 
@@ -450,6 +460,12 @@ pub struct TomlWorkspaceField {
 #[serde(default)]
 struct CargoMetadata {
     release: Option<Config>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RateLimit {
+    pub new: Option<usize>,
+    pub existing: Option<usize>,
 }
 
 pub fn load_workspace_config(

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -239,7 +239,7 @@ pub fn verify_rate_limit(
 
     let rate_limit_config = ws_config.rate_limit();
 
-    if rate_limit_config.new.unwrap_or(5) < new {
+    if rate_limit_config.new_packages.unwrap_or(5) < new {
         // "The rate limit for creating new crates is 1 crate every 10 minutes, with a burst of 5 crates."
         success = false;
         let _ = crate::ops::shell::log(
@@ -247,17 +247,17 @@ pub fn verify_rate_limit(
             format!(
                 "attempting to publish {} new crates which is above the {} rate limit: {}",
                 new,
-                if rate_limit_config.new.is_some() {
+                if rate_limit_config.new_packages.is_some() {
                     "project"
                 } else {
                     "crates.io"
                 },
-                rate_limit_config.new.unwrap_or(5)
+                rate_limit_config.new_packages.unwrap_or(5)
             ),
         );
     }
 
-    if rate_limit_config.existing.unwrap_or(30) < existing {
+    if rate_limit_config.existing_packages.unwrap_or(30) < existing {
         // "The rate limit for new versions of existing crates is 1 per minute, with a burst of 30 crates, so when releasing new versions of these crates, you shouldn't hit the limit."
         success = false;
         let _ = crate::ops::shell::log(
@@ -265,12 +265,12 @@ pub fn verify_rate_limit(
             format!(
                 "attempting to publish {} existing crates which is above the {} rate limit: {}",
                 existing,
-                if rate_limit_config.existing.is_some() {
+                if rate_limit_config.existing_packages.is_some() {
                     "project"
                 } else {
                     "crates.io"
                 },
-                rate_limit_config.existing.unwrap_or(30)
+                rate_limit_config.existing_packages.unwrap_or(30)
             ),
         );
     }

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -245,13 +245,8 @@ pub fn verify_rate_limit(
         let _ = crate::ops::shell::log(
             level,
             format!(
-                "attempting to publish {} new crates which is above the {} rate limit: {}",
+                "attempting to publish {} new crates which is above the rate limit: {}",
                 new,
-                if rate_limit_config.new_packages.is_some() {
-                    "project"
-                } else {
-                    "crates.io"
-                },
                 rate_limit_config.new_packages.unwrap_or(5)
             ),
         );
@@ -263,13 +258,8 @@ pub fn verify_rate_limit(
         let _ = crate::ops::shell::log(
             level,
             format!(
-                "attempting to publish {} existing crates which is above the {} rate limit: {}",
+                "attempting to publish {} existing crates which is above the rate limit: {}",
                 existing,
-                if rate_limit_config.existing_packages.is_some() {
-                    "project"
-                } else {
-                    "crates.io"
-                },
                 rate_limit_config.existing_packages.unwrap_or(30)
             ),
         );

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -237,26 +237,28 @@ pub fn verify_rate_limit(
         }
     }
 
-    if rate_limit.new_packages < new {
+    if rate_limit.new_packages() < new {
         // "The rate limit for creating new crates is 1 crate every 10 minutes, with a burst of 5 crates."
         success = false;
         let _ = crate::ops::shell::log(
             level,
             format!(
                 "attempting to publish {} new crates which is above the rate limit: {}",
-                new, rate_limit.new_packages
+                new,
+                rate_limit.new_packages()
             ),
         );
     }
 
-    if rate_limit.existing_packages < existing {
+    if rate_limit.existing_packages() < existing {
         // "The rate limit for new versions of existing crates is 1 per minute, with a burst of 30 crates, so when releasing new versions of these crates, you shouldn't hit the limit."
         success = false;
         let _ = crate::ops::shell::log(
             level,
             format!(
                 "attempting to publish {} existing crates which is above the rate limit: {}",
-                existing, rate_limit.existing_packages
+                existing,
+                rate_limit.existing_packages()
             ),
         );
     }

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -237,30 +237,31 @@ pub fn verify_rate_limit(
         }
     }
 
-    let rate_limit_config = ws_config.rate_limit();
+    let (new_rate_limit, existing_rate_limit) = (
+        ws_config.rate_limit_for_new_packages(),
+        ws_config.rate_limit_for_existing_packages(),
+    );
 
-    if rate_limit_config.new_packages.unwrap_or(5) < new {
+    if new_rate_limit < new {
         // "The rate limit for creating new crates is 1 crate every 10 minutes, with a burst of 5 crates."
         success = false;
         let _ = crate::ops::shell::log(
             level,
             format!(
                 "attempting to publish {} new crates which is above the rate limit: {}",
-                new,
-                rate_limit_config.new_packages.unwrap_or(5)
+                new, new_rate_limit
             ),
         );
     }
 
-    if rate_limit_config.existing_packages.unwrap_or(30) < existing {
+    if existing_rate_limit < existing {
         // "The rate limit for new versions of existing crates is 1 per minute, with a burst of 30 crates, so when releasing new versions of these crates, you shouldn't hit the limit."
         success = false;
         let _ = crate::ops::shell::log(
             level,
             format!(
                 "attempting to publish {} existing crates which is above the rate limit: {}",
-                existing,
-                rate_limit_config.existing_packages.unwrap_or(30)
+                existing, existing_rate_limit
             ),
         );
     }

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -138,7 +138,7 @@ impl PublishStep {
         failed |= !super::verify_rate_limit(
             &selected_pkgs,
             &mut index,
-            ws_config.rate_limit(),
+            &ws_config.rate_limit,
             dry_run,
             log::Level::Error,
         )?;

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -135,8 +135,13 @@ impl PublishStep {
         )?;
 
         failed |= !super::verify_metadata(&selected_pkgs, dry_run, log::Level::Error)?;
-        failed |=
-            !super::verify_rate_limit(&selected_pkgs, &mut index, dry_run, log::Level::Error)?;
+        failed |= !super::verify_rate_limit(
+            &selected_pkgs,
+            &mut index,
+            &ws_config,
+            dry_run,
+            log::Level::Error,
+        )?;
 
         // STEP 1: Release Confirmation
         super::confirm("Publish", &selected_pkgs, self.no_confirm, dry_run)?;

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -138,7 +138,7 @@ impl PublishStep {
         failed |= !super::verify_rate_limit(
             &selected_pkgs,
             &mut index,
-            &ws_config,
+            ws_config.rate_limit(),
             dry_run,
             log::Level::Error,
         )?;

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -248,7 +248,7 @@ impl ReleaseStep {
         failed |= !super::verify_rate_limit(
             &selected_pkgs,
             &mut index,
-            ws_config.rate_limit(),
+            &ws_config.rate_limit,
             dry_run,
             log::Level::Error,
         )?;

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -245,8 +245,13 @@ impl ReleaseStep {
         )?;
 
         failed |= !super::verify_metadata(&selected_pkgs, dry_run, log::Level::Error)?;
-        failed |=
-            !super::verify_rate_limit(&selected_pkgs, &mut index, dry_run, log::Level::Error)?;
+        failed |= !super::verify_rate_limit(
+            &selected_pkgs,
+            &mut index,
+            &ws_config,
+            dry_run,
+            log::Level::Error,
+        )?;
 
         // STEP 1: Release Confirmation
         super::confirm("Release", &selected_pkgs, self.no_confirm, dry_run)?;

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -248,7 +248,7 @@ impl ReleaseStep {
         failed |= !super::verify_rate_limit(
             &selected_pkgs,
             &mut index,
-            &ws_config,
+            ws_config.rate_limit(),
             dry_run,
             log::Level::Error,
         )?;


### PR DESCRIPTION
Closes: #790

With this PR, we should be able to include this in a workspace `Cargo.toml`:

```toml
[workspace.metadata.release]
rate-limit = { existing-packages = 50 }
```

This would allow a maximum of 50 crates to be published together. This is currently hard-coded to be 30.