### PR TITLE
fix(publish): Remove our own waiting logic

### DIFF
--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -321,7 +321,7 @@ impl ReleaseStep {
         }
 
         // STEP 3: cargo publish
-        super::publish::publish(&ws_meta, &selected_pkgs, &mut index, dry_run)?;
+        super::publish::publish(&ws_meta, &selected_pkgs, dry_run)?;
         super::owner::ensure_owners(&selected_pkgs, dry_run)?;
 
         // STEP 5: Tag


### PR DESCRIPTION
This has been available in Cargo since 1.66 (2022-12-15) and keeps being a source of problems.

Fixes #813