### PR TITLE
feat: Out more error info with cmd run failed

### DIFF
--- a/src/ops/cmd.rs
+++ b/src/ops/cmd.rs
@@ -38,12 +38,17 @@ fn do_call(
         }
     }
 
+    let ctx_dir = match path {
+        Some(p) => format!(" within {}", p.display()),
+        None => String::new(),
+    };
+
     let mut child = cmd
         .spawn()
-        .map_err(|e| anyhow::format_err!("failed to launch `{cmd_name}`: {e}"))?;
+        .map_err(|e| anyhow::format_err!("failed to launch `{cmd_name}`{ctx_dir}: {e}"))?;
     let result = child
         .wait()
-        .map_err(|e| anyhow::format_err!("failed to launch `{cmd_name}`: {e}"))?;
+        .map_err(|e| anyhow::format_err!("failed to launch `{cmd_name}`{ctx_dir}: {e}"))?;
 
     Ok(result.success())
 }


### PR DESCRIPTION
There are two reason for this pr:
1. `std::process.Command` recommended us to use canonicalize instead of current_dir [doc](https://doc.rust-lang.org/std/process/struct.Command.html#method.current_dir)
2. Convert to absolute path make us easier to locate problems.
    Before:
    <img width="826" alt="image" src="https://github.com/user-attachments/assets/4afc7858-85eb-400e-a3d6-8aff99acf4b7">
    After:
    <img width="1417" alt="image" src="https://github.com/user-attachments/assets/c3334d63-5e2c-45c2-927a-3075760393af">

