### PR TITLE
chore: Allow Unicode-3.0 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -94,6 +94,7 @@ allow = [
     "CC0-1.0",
     "ISC",
     "OpenSSL",
+    "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
As seen in https://github.com/crate-ci/cargo-release/actions/runs/16806472644/job/47600100400, there are currently multiple crates in dependency tree that already use the Unicode-3.0 license. Since this has not been deemed sufficient reason to remove those crates from the tree, the license should be allow-listed to reduce spurious CI errors.