### PR TITLE
docs: Use mdsh to keep reference doc up-to-date

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,8 @@ repos:
     rev: v1.1.7
     hooks:
     - id: committed
+  - repo: https://github.com/zimbatm/mdsh.git
+    rev: v0.9.2
+    hooks:
+    - id: mdsh
+      files: ".*\\.md"

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Features include:
 
 Current release: 0.25.18
 
-```console,ignore
-$ cargo install cargo-release
+```sh
+cargo install cargo-release
 ```
 
 ## Usage
 
-```console,ignore
+```console
 $ cargo release [level]
 <dry-run output>
 $ cargo release [level] --execute

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,8 +2,10 @@
 
 ## CLI Arguments
 
+<!-- `$ echo '$ cargo release -h' && cargo run --quiet -- release -h` as console -->
+
 ```console
-$ cargo-release release -h
+$ cargo release -h
 Cargo subcommand for you to smooth your release process.
 
 Usage: cargo release [OPTIONS] [LEVEL|VERSION]
@@ -71,7 +73,6 @@ Tag:
 Push:
       --no-push             Do not run git push in the last step
       --push-remote <NAME>  Git remote to push
-
 ```
 
 ### Bump level


### PR DESCRIPTION
This is partially a follow-up to #840; the `cargo install` block is changed to a raw shell command for easier copy-paste.