### PR TITLE
feat(commit): Enable variable expansion for workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- Enable variable expansion (`{{crate_name}}`, etc) for single-crate workspace releases
+
 ## [0.25.22] - 2025-11-13
 
 ### Fixes


### PR DESCRIPTION
When releasing a single crate within a workspace,
`pre-release-commit-message` can now use crate-specific variables like `{{crate_name}}`, `{{version}}`, `{{prev_version}}`, etc., similar to non-workspace releases.

Previously, workspace commits only supported `{{version}}` (if shared) and `{{date}}`, even when only one crate was being released.

Related #917 