### PR TITLE
[WIP][Draft][Experiment]Implement crate lookup in custom remote registries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "bstr",
  "cargo-test-support",
  "cargo_metadata",
+ "cargo_utils",
  "clap",
  "clap-cargo",
  "dirs-next",
@@ -255,6 +256,7 @@ dependencies = [
  "predicates",
  "quick-error",
  "regex",
+ "secrecy",
  "semver",
  "serde",
  "similar",
@@ -337,6 +339,25 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "cargo_utils"
+version = "0.1.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "802ead07a272fa987e1d5e2c4ac3a66d26df96c7168b93eefb4d6db93609579d"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "dirs",
+ "dunce",
+ "fs-err",
+ "secrecy",
+ "semver",
+ "serde",
+ "toml",
+ "toml_edit",
+ "url",
 ]
 
 [[package]]
@@ -635,6 +656,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,13 +675,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -840,6 +882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1596,6 +1647,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orion"
 version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,6 +1992,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,6 +2212,15 @@ dependencies = [
  "generic-array",
  "pkcs8",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,8 @@ anyhow = "1.0.100"
 git-conventional = "0.12.9"
 similar = "2.7"
 anstream = "0.6.20"
+cargo_utils = "0.1.75"
+secrecy = "0.10.3"
 
 [dev-dependencies]
 assert_fs = "1.1"

--- a/src/ops/cargo.rs
+++ b/src/ops/cargo.rs
@@ -122,13 +122,14 @@ pub fn publish(
 }
 
 pub fn is_published(
-    index: &mut crate::ops::index::CratesIoIndex,
+    index: &mut crate::ops::index::CratesIndex,
+    manifest: &Path,
     registry: Option<&str>,
     name: &str,
     version: &str,
     certs_source: CertsSource,
 ) -> bool {
-    match index.has_krate_version(registry, name, version, certs_source) {
+    match index.has_krate_version(manifest, registry, name, version, certs_source) {
         Ok(has_krate_version) => has_krate_version.unwrap_or(false),
         Err(err) => {
             // For both http and git indices, this _might_ be an error that goes away in

--- a/src/steps/hook.rs
+++ b/src/steps/hook.rs
@@ -51,7 +51,7 @@ pub struct HookStep {
 impl HookStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
-        let mut index = crate::ops::index::CratesIoIndex::new();
+        let mut index = crate::ops::index::CratesIndex::new();
 
         if self.dry_run {
             let _ =
@@ -95,6 +95,7 @@ impl HookStep {
                 let version = &pkg.initial_version;
                 if !crate::ops::cargo::is_published(
                     &mut index,
+                    &pkg.manifest_path,
                     pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -212,7 +212,7 @@ pub fn verify_monotonically_increasing(
 
 pub fn verify_rate_limit(
     pkgs: &[plan::PackageRelease],
-    index: &mut crate::ops::index::CratesIoIndex,
+    index: &mut crate::ops::index::CratesIndex,
     rate_limit: &crate::config::RateLimit,
     dry_run: bool,
     level: log::Level,
@@ -228,7 +228,12 @@ pub fn verify_rate_limit(
         // Note: these rate limits are only known for default registry
         if pkg.config.registry().is_none() && pkg.config.publish() {
             let crate_name = pkg.meta.name.as_str();
-            if index.has_krate(None, crate_name, pkg.config.certs_source())? {
+            if index.has_krate(
+                &pkg.manifest_path,
+                None,
+                crate_name,
+                pkg.config.certs_source(),
+            )? {
                 existing += 1;
             } else {
                 new += 1;

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -84,13 +84,14 @@ impl PublishStep {
 
         let mut pkgs = plan::plan(pkgs)?;
 
-        let mut index = crate::ops::index::CratesIoIndex::new();
+        let mut index = crate::ops::index::CratesIndex::new();
         for pkg in pkgs.values_mut() {
             if pkg.config.release() {
                 let crate_name = pkg.meta.name.as_str();
                 let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
                 if crate::ops::cargo::is_published(
                     &mut index,
+                    &pkg.manifest_path,
                     pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -46,7 +46,7 @@ pub struct ReleaseStep {
 impl ReleaseStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
-        let mut index = crate::ops::index::CratesIoIndex::new();
+        let mut index = crate::ops::index::CratesIndex::new();
 
         if self.dry_run {
             let _ =
@@ -74,6 +74,7 @@ impl ReleaseStep {
                 pkg.bump(level_or_version, self.metadata.as_deref())?;
             }
             if index.has_krate(
+                &pkg.manifest_path,
                 pkg.config.registry(),
                 &pkg.meta.name,
                 pkg.config.certs_source(),
@@ -110,6 +111,7 @@ impl ReleaseStep {
                 let version = &pkg.initial_version;
                 if !cargo::is_published(
                     &mut index,
+                    &pkg.manifest_path,
                     pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,
@@ -158,12 +160,12 @@ impl ReleaseStep {
                 continue;
             };
 
-            // HACK: `index` only supports default registry
-            if pkg.config.publish() && pkg.config.registry().is_none() {
+            if pkg.config.publish() {
                 let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
                 let crate_name = pkg.meta.name.as_str();
                 if !cargo::is_published(
                     &mut index,
+                    &pkg.manifest_path,
                     pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,
@@ -213,6 +215,7 @@ impl ReleaseStep {
             let crate_name = pkg.meta.name.as_str();
             if cargo::is_published(
                 &mut index,
+                &pkg.manifest_path,
                 pkg.config.registry(),
                 crate_name,
                 &version.full_version_string,

--- a/src/steps/replace.rs
+++ b/src/steps/replace.rs
@@ -47,7 +47,7 @@ pub struct ReplaceStep {
 impl ReplaceStep {
     pub fn run(&self) -> Result<(), CliError> {
         git::git_version()?;
-        let mut index = crate::ops::index::CratesIoIndex::new();
+        let mut index = crate::ops::index::CratesIndex::new();
 
         if self.dry_run {
             let _ =
@@ -91,6 +91,7 @@ impl ReplaceStep {
                 let version = &pkg.initial_version;
                 if !crate::ops::cargo::is_published(
                     &mut index,
+                    &pkg.manifest_path,
                     pkg.config.registry(),
                     crate_name,
                     &version.full_version_string,


### PR DESCRIPTION
As an attempt to fix #670 using the `cargo_utils` crate to resolve registry urls.

Test with `cargo release publish --workspace --registry <your_registry>`

Missing/TODO:
* Hard: Resolve the registry to publish each package to. Currently needs `config.registry` (passed via CLI)
* Investigate why it only works for `cargo release publish` but not for `cargo release`
* Tests

