### PR TITLE
feat: Add {{major}}, {{minor}}, {{patch}} template variables

### DIFF
--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -19,6 +19,9 @@ pub struct Template<'a> {
     pub crate_name: Option<&'a str>,
     pub repository: Option<&'a str>,
     pub date: Option<&'a str>,
+    pub major: Option<&'a str>,
+    pub minor: Option<&'a str>,
+    pub patch: Option<&'a str>,
 
     pub prefix: Option<&'a str>,
     pub tag_name: Option<&'a str>,
@@ -33,6 +36,9 @@ impl Template<'_> {
         const CRATE_NAME: &str = "{{crate_name}}";
         const REPOSITORY: &str = "{{repository}}";
         const DATE: &str = "{{date}}";
+        const MAJOR: &str = "{{major}}";
+        const MINOR: &str = "{{minor}}";
+        const PATCH: &str = "{{patch}}";
 
         const PREFIX: &str = "{{prefix}}";
         const TAG_NAME: &str = "{{tag_name}}";
@@ -45,6 +51,9 @@ impl Template<'_> {
         s = render_var(s, CRATE_NAME, self.crate_name);
         s = render_var(s, REPOSITORY, self.repository);
         s = render_var(s, DATE, self.date);
+        s = render_var(s, MAJOR, self.major);
+        s = render_var(s, MINOR, self.minor);
+        s = render_var(s, PATCH, self.patch);
 
         s = render_var(s, PREFIX, self.prefix);
         s = render_var(s, TAG_NAME, self.tag_name);

--- a/src/steps/commit.rs
+++ b/src/steps/commit.rs
@@ -132,6 +132,9 @@ pub fn pkg_commit(pkg: &plan::PackageRelease, dry_run: bool) -> Result<(), CliEr
     let prev_metadata_var = pkg.initial_version.full_version.build.as_str();
     let version_var = version.bare_version_string.as_str();
     let metadata_var = version.full_version.build.as_str();
+    let major_var = version.bare_version.major.to_string();
+    let minor_var = version.bare_version.minor.to_string();
+    let patch_var = version.bare_version.patch.to_string();
     let template = Template {
         prev_version: Some(prev_version_var),
         prev_metadata: Some(prev_metadata_var),
@@ -139,6 +142,9 @@ pub fn pkg_commit(pkg: &plan::PackageRelease, dry_run: bool) -> Result<(), CliEr
         metadata: Some(metadata_var),
         crate_name: Some(crate_name),
         date: Some(NOW.as_str()),
+        major: Some(&major_var),
+        minor: Some(&minor_var),
+        patch: Some(&patch_var),
         ..Default::default()
     };
     let commit_msg = template.render(pkg.config.pre_release_commit_message());
@@ -166,10 +172,22 @@ pub fn workspace_commit(
         let metadata_var = shared_version
             .as_ref()
             .map(|v| v.full_version.build.as_str());
+        let major_var = shared_version
+            .as_ref()
+            .map(|v| v.bare_version.major.to_string());
+        let minor_var = shared_version
+            .as_ref()
+            .map(|v| v.bare_version.minor.to_string());
+        let patch_var = shared_version
+            .as_ref()
+            .map(|v| v.bare_version.patch.to_string());
         let template = Template {
             version: version_var,
             metadata: metadata_var,
             date: Some(NOW.as_str()),
+            major: major_var.as_deref(),
+            minor: minor_var.as_deref(),
+            patch: patch_var.as_deref(),
             ..Default::default()
         };
         template.render(ws_config.pre_release_commit_message())

--- a/src/steps/hook.rs
+++ b/src/steps/hook.rs
@@ -185,6 +185,9 @@ pub fn hook(
         let prev_metadata_var = pkg.initial_version.full_version.build.as_str();
         let version_var = version.bare_version_string.as_str();
         let metadata_var = version.full_version.build.as_str();
+        let major_var = version.bare_version.major.to_string();
+        let minor_var = version.bare_version.minor.to_string();
+        let patch_var = version.bare_version.patch.to_string();
         let template = Template {
             prev_version: Some(prev_version_var),
             prev_metadata: Some(prev_metadata_var),
@@ -193,6 +196,9 @@ pub fn hook(
             crate_name: Some(crate_name),
             date: Some(NOW.as_str()),
             tag_name: pkg.planned_tag.as_deref(),
+            major: Some(&major_var),
+            minor: Some(&minor_var),
+            patch: Some(&patch_var),
             ..Default::default()
         };
         let pre_rel_hook = pre_rel_hook
@@ -206,6 +212,9 @@ pub fn hook(
             OsStr::new("PREV_METADATA") => prev_metadata_var.as_ref(),
             OsStr::new("NEW_VERSION") => version_var.as_ref(),
             OsStr::new("NEW_METADATA") => metadata_var.as_ref(),
+            OsStr::new("NEW_MAJOR") => OsStr::new(major_var.as_str()),
+            OsStr::new("NEW_MINOR") => OsStr::new(minor_var.as_str()),
+            OsStr::new("NEW_PATCH") => OsStr::new(patch_var.as_str()),
             OsStr::new("DRY_RUN") => OsStr::new(if dry_run { "true" } else { "false" }),
             OsStr::new("CRATE_NAME") => OsStr::new(crate_name),
             OsStr::new("WORKSPACE_ROOT") => ws_meta.workspace_root.as_os_str(),

--- a/src/steps/plan.rs
+++ b/src/steps/plan.rs
@@ -279,12 +279,18 @@ fn render_tag(
     let existing_metadata_var = prev.full_version.build.as_str();
     let version_var = base.bare_version_string.as_str();
     let metadata_var = base.full_version.build.as_str();
+    let major_var = base.bare_version.major.to_string();
+    let minor_var = base.bare_version.minor.to_string();
+    let patch_var = base.bare_version.patch.to_string();
     let mut template = Template {
         prev_version: Some(initial_version_var),
         prev_metadata: Some(existing_metadata_var),
         version: Some(version_var),
         metadata: Some(metadata_var),
         crate_name: Some(name),
+        major: Some(&major_var),
+        minor: Some(&minor_var),
+        patch: Some(&patch_var),
         ..Default::default()
     };
 
@@ -304,6 +310,9 @@ fn render_tag_glob(tag_name: &str, tag_prefix: &str, name: &str) -> String {
         version: Some(version_var),
         metadata: Some(metadata_var),
         crate_name: Some(name),
+        major: Some("*"),
+        minor: Some("*"),
+        patch: Some("*"),
         ..Default::default()
     };
 

--- a/src/steps/replace.rs
+++ b/src/steps/replace.rs
@@ -177,6 +177,9 @@ pub fn replace(pkg: &plan::PackageRelease, dry_run: bool) -> Result<(), CliError
         let prev_metadata_var = pkg.initial_version.full_version.build.as_str();
         let version_var = version.bare_version_string.as_str();
         let metadata_var = version.full_version.build.as_str();
+        let major_var = version.bare_version.major.to_string();
+        let minor_var = version.bare_version.minor.to_string();
+        let patch_var = version.bare_version.patch.to_string();
         // try replacing text in configured files
         let template = Template {
             prev_version: Some(prev_version_var),
@@ -187,6 +190,9 @@ pub fn replace(pkg: &plan::PackageRelease, dry_run: bool) -> Result<(), CliError
             repository: pkg.meta.repository.as_deref(),
             date: Some(NOW.as_str()),
             tag_name: pkg.planned_tag.as_deref(),
+            major: Some(&major_var),
+            minor: Some(&minor_var),
+            patch: Some(&patch_var),
             ..Default::default()
         };
         let prerelease = version.is_prerelease();

--- a/src/steps/tag.rs
+++ b/src/steps/tag.rs
@@ -169,6 +169,9 @@ pub fn tag(pkgs: &[plan::PackageRelease], dry_run: bool) -> Result<(), CliError>
             let prev_metadata_var = pkg.initial_version.full_version.build.as_str();
             let version_var = version.bare_version_string.as_str();
             let metadata_var = version.full_version.build.as_str();
+            let major_var = version.bare_version.major.to_string();
+            let minor_var = version.bare_version.minor.to_string();
+            let patch_var = version.bare_version.patch.to_string();
             let template = Template {
                 prev_version: Some(prev_version_var),
                 prev_metadata: Some(prev_metadata_var),
@@ -177,6 +180,9 @@ pub fn tag(pkgs: &[plan::PackageRelease], dry_run: bool) -> Result<(), CliError>
                 crate_name: Some(crate_name),
                 date: Some(NOW.as_str()),
                 tag_name: Some(tag_name),
+                major: Some(&major_var),
+                minor: Some(&minor_var),
+                patch: Some(&patch_var),
                 ..Default::default()
             };
             let tag_message = template.render(pkg.config.tag_message());


### PR DESCRIPTION
I would like to advertise a major.minor version in my README dependency examples (e.g. `my-crate = "0.3"`).

Using {{version}} produces the full semver which is too precise. These new template variables allow:

  replace = 'my-crate = "{{major}}.{{minor}}"'

Also exposes NEW_MAJOR, NEW_MINOR, NEW_PATCH environment variables in pre-release hooks.

Relates to #116

I realize there are plans for a new templating system. Consider this a short-term solution to fix a need.