### PR TITLE
fix: avoid panic when hook is empty array

### DIFF
--- a/src/ops/cmd.rs
+++ b/src/ops/cmd.rs
@@ -12,6 +12,11 @@ fn do_call(
     dry_run: bool,
 ) -> CargoResult<bool> {
     let command: Vec<_> = command.into_iter().map(|s| s.into()).collect();
+    
+    if command.is_empty() {
+        return Ok(true);
+    }
+    
     if let Some(path) = path {
         log::trace!("cd {}", path.display());
     }


### PR DESCRIPTION
Fixes #945

## Problem
When configuring `pre-release-hook = []` (empty array), the tool would panic with `unwrap` on a `None` value.

## Solution
Add an early return when the command vector is empty, which:
- Prevents the panic
- Treats empty hooks as "no operation" (standard CLI behavior)
- Is a minimal, safe change with no breaking changes

## Testing
- Verified with `pre-release-hook = []`
- No panic, runs successfully
- Dry-run and normal modes both work correctly