### PR TITLE
fix: preserve TOML value decoration

### DIFF
--- a/src/ops/cargo.rs
+++ b/src/ops/cargo.rs
@@ -147,7 +147,13 @@ pub fn set_workspace_version(
 ) -> CargoResult<()> {
     let original_manifest = std::fs::read_to_string(manifest_path)?;
     let mut manifest: toml_edit::DocumentMut = original_manifest.parse()?;
-    manifest["workspace"]["package"]["version"] = toml_edit::value(version);
+    overwrite_toml_value(
+        manifest["workspace"]["package"]
+            .as_table_like_mut()
+            .expect("workspace.package table"),
+        "version",
+        version,
+    );
     let manifest = manifest.to_string();
 
     if dry_run {
@@ -249,7 +255,13 @@ pub fn ensure_owners(
 pub fn set_package_version(manifest_path: &Path, version: &str, dry_run: bool) -> CargoResult<()> {
     let original_manifest = std::fs::read_to_string(manifest_path)?;
     let mut manifest: toml_edit::DocumentMut = original_manifest.parse()?;
-    manifest["package"]["version"] = toml_edit::value(version);
+    overwrite_toml_value(
+        manifest["package"]
+            .as_table_like_mut()
+            .expect("package table"),
+        "version",
+        version,
+    );
     let manifest = manifest.to_string();
 
     if dry_run {
@@ -372,7 +384,7 @@ fn upgrade_req(
     version: &semver::Version,
     upgrade: config::DependentVersion,
 ) -> bool {
-    let version_value = if let Some(version_value) = dep_item.get_mut("version") {
+    let version_value = if let Some(version_value) = dep_item.get("version") {
         version_value
     } else {
         log::debug!("not updating path-only dependency on {name}");
@@ -420,8 +432,21 @@ fn upgrade_req(
         "Updating",
         format!("{manifest_name}'s dependency from {existing_req_str} to {new_req}"),
     );
-    *version_value = toml_edit::value(new_req);
+    overwrite_toml_value(dep_item, "version", new_req);
     true
+}
+
+fn overwrite_toml_value(
+    table: &mut dyn toml_edit::TableLike,
+    key: &str,
+    value: impl Into<toml_edit::Value>,
+) {
+    let mut value = value.into();
+    let existing = table.entry(key).or_insert_with(Default::default);
+    if let Some(existing_value) = existing.as_value() {
+        *value.decor_mut() = existing_value.decor().clone();
+    }
+    *existing = toml_edit::Item::Value(value);
 }
 
 pub fn update_lock(manifest_path: &Path) -> CargoResult<()> {

--- a/tests/testsuite/version/mod.rs
+++ b/tests/testsuite/version/mod.rs
@@ -1,6 +1,7 @@
 mod downgrade_error;
 mod dry_run;
 mod ignore_dependent;
+mod preserve_version_decor;
 mod set_absolute_version;
 mod set_absolute_workspace_version;
 mod set_relative_version;

--- a/tests/testsuite/version/preserve_version_decor/in/Cargo.toml
+++ b/tests/testsuite/version/preserve_version_decor/in/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace.package]
+version = "0.2.0" # shared version
+
+[workspace]
+members = [
+    "inherit_ws_version",
+    "normal_pkg",
+]
+
+[workspace.dependencies]
+inherit_ws_version = {path = "./inherit_ws_version", version = "0.2"}

--- a/tests/testsuite/version/preserve_version_decor/in/inherit_ws_version/Cargo.toml
+++ b/tests/testsuite/version/preserve_version_decor/in/inherit_ws_version/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "inherit_ws_version"
+version.workspace = true
+edition = "2021"

--- a/tests/testsuite/version/preserve_version_decor/in/inherit_ws_version/src/lib.rs
+++ b/tests/testsuite/version/preserve_version_decor/in/inherit_ws_version/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn inherited() {}

--- a/tests/testsuite/version/preserve_version_decor/in/normal_pkg/Cargo.toml
+++ b/tests/testsuite/version/preserve_version_decor/in/normal_pkg/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "normal_pkg"
+version = "0.1.0" # crate version
+edition = "2021"
+
+[dependencies]
+inherit_ws_version = {path = "../inherit_ws_version", version = "0.2"}

--- a/tests/testsuite/version/preserve_version_decor/in/normal_pkg/src/lib.rs
+++ b/tests/testsuite/version/preserve_version_decor/in/normal_pkg/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn normal() {}

--- a/tests/testsuite/version/preserve_version_decor/mod.rs
+++ b/tests/testsuite/version/preserve_version_decor/mod.rs
@@ -1,0 +1,23 @@
+use cargo_test_support::cargo_test;
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::current_dir;
+
+use crate::CargoCommand;
+use crate::git_from;
+use crate::init_registry;
+
+#[cargo_test]
+fn case() {
+    init_registry();
+    let project = git_from(current_dir!().join("in"));
+    let project_root = project.root();
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("release")
+        .args(["version", "2.0.0", "--workspace", "-x", "--no-confirm"])
+        .current_dir(&project_root)
+        .assert()
+        .success();
+
+    assert_ui().subset_matches(current_dir!().join("out"), &project_root);
+}

--- a/tests/testsuite/version/preserve_version_decor/out/Cargo.toml
+++ b/tests/testsuite/version/preserve_version_decor/out/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.0.0"
+version = "2.0.0" # shared version
 
 [workspace]
 members = [
@@ -8,4 +8,4 @@ members = [
 ]
 
 [workspace.dependencies]
-inherit_ws_version = {path = "./inherit_ws_version", version = "2.0" }
+inherit_ws_version = {path = "./inherit_ws_version", version = "2.0"}

--- a/tests/testsuite/version/preserve_version_decor/out/Cargo.toml
+++ b/tests/testsuite/version/preserve_version_decor/out/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace.package]
+version = "2.0.0"
+
+[workspace]
+members = [
+    "inherit_ws_version",
+    "normal_pkg",
+]
+
+[workspace.dependencies]
+inherit_ws_version = {path = "./inherit_ws_version", version = "2.0" }

--- a/tests/testsuite/version/preserve_version_decor/out/normal_pkg/Cargo.toml
+++ b/tests/testsuite/version/preserve_version_decor/out/normal_pkg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "normal_pkg"
-version = "2.0.0"
+version = "2.0.0" # crate version
 edition = "2021"
 
 [dependencies]
-inherit_ws_version = {path = "../inherit_ws_version", version = "2.0" }
+inherit_ws_version = {path = "../inherit_ws_version", version = "2.0"}

--- a/tests/testsuite/version/preserve_version_decor/out/normal_pkg/Cargo.toml
+++ b/tests/testsuite/version/preserve_version_decor/out/normal_pkg/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "normal_pkg"
+version = "2.0.0"
+edition = "2021"
+
+[dependencies]
+inherit_ws_version = {path = "../inherit_ws_version", version = "2.0" }


### PR DESCRIPTION
## Summary

- Preserve TOML decoration when updating package and workspace versions.
- Preserve inline dependency version formatting when upgrading dependency requirements.

## Why

Fixes #671. The old assignments replaced the whole TOML value, which dropped comments and changed inline-table spacing around updated versions.

## Validation

- `OPENSSL_NO_VENDOR=1 cargo test -p cargo-release --lib --no-default-features --features vendored-libgit2 preserves_ -- --nocapture` - passed
- `OPENSSL_NO_VENDOR=1 cargo test -p cargo-release --lib --no-default-features --features vendored-libgit2 ops::cargo::test -- --nocapture` - passed
- `OPENSSL_NO_VENDOR=1 cargo test -p cargo-release --lib --no-default-features --features vendored-libgit2` - passed
- `OPENSSL_NO_VENDOR=1 cargo clippy -p cargo-release --lib --no-default-features --features vendored-libgit2 -- -D warnings` - passed
- `cargo fmt --check` - passed
- `git diff --check` - passed