### PR TITLE
feat: allow dirty worktrees for publish step

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -74,6 +74,10 @@ Push:
 
 ```
 
+The standalone publish step accepts `--allow-dirty` to publish with uncommitted
+changes, matching `cargo publish --allow-dirty`. The full release workflow
+continues to require a clean working tree because it creates commits.
+
 ### Bump level
 
 * `release` (default): Remove the pre-release extension; if any (0.1.0-alpha.1 -> 0.1.0, 0.1.0 -> 0.1.0).

--- a/src/ops/cargo.rs
+++ b/src/ops/cargo.rs
@@ -52,6 +52,7 @@ pub fn package_content(manifest_path: &Path) -> CargoResult<Vec<std::path::PathB
 
 pub fn publish(
     dry_run: bool,
+    allow_dirty: bool,
     verify: bool,
     manifest_path: &Path,
     pkgids: &[&str],
@@ -84,6 +85,8 @@ pub fn publish(
 
     if dry_run {
         command.push("--dry-run");
+    }
+    if dry_run || allow_dirty {
         command.push("--allow-dirty");
     }
 

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -38,6 +38,10 @@ pub struct PublishStep {
     #[arg(short = 'n', long, conflicts_with = "execute", hide = true)]
     dry_run: bool,
 
+    /// Allow publishing with uncommitted changes
+    #[arg(long)]
+    allow_dirty: bool,
+
     /// Skip release confirmation and version preview
     #[arg(long)]
     no_confirm: bool,
@@ -119,11 +123,13 @@ impl PublishStep {
         let mut failed = false;
 
         // STEP 0: Help the user make the right decisions.
-        failed |= !super::verify_git_is_clean(
-            ws_meta.workspace_root.as_std_path(),
-            dry_run,
-            log::Level::Error,
-        )?;
+        if !self.allow_dirty {
+            failed |= !super::verify_git_is_clean(
+                ws_meta.workspace_root.as_std_path(),
+                dry_run,
+                log::Level::Error,
+            )?;
+        }
 
         failed |= !super::verify_git_branch(
             ws_meta.workspace_root.as_std_path(),
@@ -152,7 +158,7 @@ impl PublishStep {
         super::confirm("Publish", &selected_pkgs, self.no_confirm, dry_run)?;
 
         // STEP 3: cargo publish
-        publish(&selected_pkgs, dry_run)?;
+        publish(&selected_pkgs, dry_run, self.allow_dirty)?;
 
         super::finish(failed, dry_run)
     }
@@ -169,7 +175,11 @@ impl PublishStep {
     }
 }
 
-pub fn publish(pkgs: &[plan::PackageRelease], dry_run: bool) -> Result<(), CliError> {
+pub fn publish(
+    pkgs: &[plan::PackageRelease],
+    dry_run: bool,
+    allow_dirty: bool,
+) -> Result<(), CliError> {
     if pkgs.is_empty() {
         Ok(())
     } else {
@@ -183,9 +193,9 @@ pub fn publish(pkgs: &[plan::PackageRelease], dry_run: bool) -> Result<(), CliEr
                 .all(|p| p.config.registry() == registry && p.config.target.as_deref() == target)
         {
             let manifest_path = &first_pkg.manifest_path;
-            workspace_publish(manifest_path, pkgs, registry, target, dry_run)
+            workspace_publish(manifest_path, pkgs, registry, target, dry_run, allow_dirty)
         } else {
-            serial_publish(pkgs, publish_grace_sleep, dry_run)
+            serial_publish(pkgs, publish_grace_sleep, dry_run, allow_dirty)
         }
     }
 }
@@ -196,6 +206,7 @@ fn workspace_publish(
     registry: Option<&str>,
     target: Option<&str>,
     dry_run: bool,
+    allow_dirty: bool,
 ) -> Result<(), CliError> {
     let crate_names = pkgs.iter().map(|p| p.meta.name.as_str()).join(", ");
     let _ = crate::ops::shell::status("Publishing", crate_names);
@@ -214,6 +225,7 @@ fn workspace_publish(
         .collect::<Vec<_>>();
     if !crate::ops::cargo::publish(
         dry_run,
+        allow_dirty,
         verify,
         manifest_path,
         &pkgids,
@@ -231,6 +243,7 @@ fn serial_publish(
     pkgs: &[plan::PackageRelease],
     publish_grace_sleep: Option<u64>,
     dry_run: bool,
+    allow_dirty: bool,
 ) -> Result<(), CliError> {
     for pkg in pkgs {
         if !pkg.config.publish() {
@@ -258,6 +271,7 @@ fn serial_publish(
         let pkgid = &[crate_name];
         if !crate::ops::cargo::publish(
             dry_run,
+            allow_dirty,
             verify,
             &pkg.manifest_path,
             pkgid,
@@ -292,5 +306,23 @@ fn publish_grace_sleep() -> Option<u64> {
         None
     } else {
         Some(publish_grace_sleep)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser as _;
+
+    #[derive(clap::Parser)]
+    struct Opt {
+        #[command(flatten)]
+        publish: super::PublishStep,
+    }
+
+    #[test]
+    fn allow_dirty_argument() {
+        let opt = Opt::try_parse_from(["test", "--allow-dirty"]).unwrap();
+
+        assert!(opt.publish.allow_dirty);
     }
 }

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -319,7 +319,7 @@ impl ReleaseStep {
         }
 
         // STEP 3: cargo publish
-        super::publish::publish(&selected_pkgs, dry_run)?;
+        super::publish::publish(&selected_pkgs, dry_run, false)?;
         super::owner::ensure_owners(&selected_pkgs, dry_run)?;
 
         // STEP 5: Tag


### PR DESCRIPTION
## Summary

- add `--allow-dirty` to `cargo release publish`
- skip the publish step's clean-worktree preflight only when explicitly requested
- forward `--allow-dirty` to executing `cargo publish` commands
- keep the full release workflow clean-only to avoid committing unrelated changes
- document the intentionally narrow scope

## Validation

- `cargo test --lib --bins --all-features`
- `cargo test --test readme --all-features`
- `cargo test --workspace --no-run`
- `cargo fmt --all -- --check`

Closes #1001