### PR TITLE
fix: check dependencies before publishing

### DIFF
--- a/src/ops/cargo.rs
+++ b/src/ops/cargo.rs
@@ -140,6 +140,22 @@ pub fn is_published(
     }
 }
 
+pub fn is_published_req(
+    index: &mut crate::ops::index::CratesIoIndex,
+    registry: Option<&str>,
+    name: &str,
+    version_req: &semver::VersionReq,
+    certs_source: CertsSource,
+) -> bool {
+    match index.has_krate_version_req(registry, name, version_req, certs_source) {
+        Ok(has_krate_version) => has_krate_version.unwrap_or(false),
+        Err(err) => {
+            log::warn!("failed to read metadata for {name}: {err:#}");
+            false
+        }
+    }
+}
+
 pub fn set_workspace_version(
     manifest_path: &Path,
     version: &str,

--- a/src/ops/index.rs
+++ b/src/ops/index.rs
@@ -45,6 +45,24 @@ impl CratesIoIndex {
     }
 
     #[inline]
+    pub fn has_krate_version_req(
+        &mut self,
+        registry: Option<&str>,
+        name: &str,
+        version_req: &semver::VersionReq,
+        certs_source: CertsSource,
+    ) -> Result<Option<bool>, crate::error::CliError> {
+        let krate = self.krate(registry, name, certs_source)?;
+        Ok(krate.map(|ik| {
+            ik.versions.iter().any(|iv| {
+                iv.version
+                    .parse::<semver::Version>()
+                    .is_ok_and(|version| version_req.matches(&version))
+            })
+        }))
+    }
+
+    #[inline]
     pub fn update_krate(&mut self, registry: Option<&str>, name: &str) {
         if registry.is_some() {
             return;

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -706,3 +706,86 @@ impl BumpLevel {
         Ok(())
     }
 }
+
+pub fn verify_dependencies(
+    selected_pkgs: &[plan::PackageRelease],
+    excluded_pkgs: &[plan::PackageRelease],
+    index: &mut crate::ops::index::CratesIoIndex,
+    dry_run: bool,
+    level: log::Level,
+) -> Result<bool, crate::error::CliError> {
+    let mut success = true;
+
+    for pkg in selected_pkgs {
+        if !pkg.config.publish() || pkg.config.registry().is_some() {
+            continue;
+        }
+        let version = pkg.planned_version.as_ref().unwrap_or(&pkg.initial_version);
+        let mut checked = std::collections::HashSet::new();
+        for dependency in &pkg.meta.dependencies {
+            if dependency.registry.is_some()
+                || (dependency.req == semver::VersionReq::STAR
+                    && !dependency
+                        .source
+                        .as_ref()
+                        .is_some_and(cargo_metadata::Source::is_crates_io))
+                || !checked.insert((dependency.name.as_str(), &dependency.req))
+            {
+                continue;
+            }
+
+            let publishing = selected_pkgs.iter().any(|candidate| {
+                let candidate_version = candidate
+                    .planned_version
+                    .as_ref()
+                    .unwrap_or(&candidate.initial_version);
+                candidate.config.publish()
+                    && candidate.config.registry() == pkg.config.registry()
+                    && candidate.meta.name.as_str() == dependency.name.as_str()
+                    && dependency.req.matches(&candidate_version.full_version)
+            });
+            if publishing
+                || crate::ops::cargo::is_published_req(
+                    index,
+                    pkg.config.registry(),
+                    &dependency.name,
+                    &dependency.req,
+                    pkg.config.certs_source(),
+                )
+            {
+                continue;
+            }
+
+            let workspace_dependency = selected_pkgs
+                .iter()
+                .chain(excluded_pkgs)
+                .find(|candidate| candidate.meta.name.as_str() == dependency.name.as_str());
+            let message = if let Some(workspace_dependency) = workspace_dependency {
+                let dependency_version = workspace_dependency
+                    .planned_version
+                    .as_ref()
+                    .unwrap_or(&workspace_dependency.initial_version);
+                format!(
+                    "{} {} depends on unpublished workspace package {} {}",
+                    pkg.meta.name,
+                    version.full_version_string,
+                    workspace_dependency.meta.name,
+                    dependency_version.full_version_string
+                )
+            } else {
+                format!(
+                    "{} {} depends on unpublished package {} {}",
+                    pkg.meta.name, version.full_version_string, dependency.name, dependency.req
+                )
+            };
+            let _ = crate::ops::shell::log(level, message);
+            success = false;
+        }
+    }
+
+    if !success && level == log::Level::Error && !dry_run {
+        return Err(101.into());
+    }
+
+    Ok(success)
+}

--- a/src/steps/publish.rs
+++ b/src/steps/publish.rs
@@ -106,7 +106,7 @@ impl PublishStep {
             }
         }
 
-        let (selected_pkgs, _excluded_pkgs): (Vec<_>, Vec<_>) = pkgs
+        let (selected_pkgs, excluded_pkgs): (Vec<_>, Vec<_>) = pkgs
             .into_iter()
             .map(|(_, pkg)| pkg)
             .partition(|p| p.config.release());
@@ -119,6 +119,14 @@ impl PublishStep {
         let mut failed = false;
 
         // STEP 0: Help the user make the right decisions.
+        failed |= !super::verify_dependencies(
+            &selected_pkgs,
+            &excluded_pkgs,
+            &mut index,
+            dry_run,
+            log::Level::Error,
+        )?;
+
         failed |= !super::verify_git_is_clean(
             ws_meta.workspace_root.as_std_path(),
             dry_run,

--- a/src/steps/release.rs
+++ b/src/steps/release.rs
@@ -193,6 +193,14 @@ impl ReleaseStep {
         ws_config.consolidate_commits = Some(consolidate_commits);
 
         // STEP 0: Help the user make the right decisions.
+        failed |= !super::verify_dependencies(
+            &selected_pkgs,
+            &excluded_pkgs,
+            &mut index,
+            dry_run,
+            log::Level::Error,
+        )?;
+
         failed |= !super::verify_git_is_clean(
             ws_meta.workspace_root.as_std_path(),
             dry_run,

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,10 +1,11 @@
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::redundant_clone)]
 
+mod publish;
 mod version;
 
-fn init_registry() {
-    cargo_test_support::registry::init();
+fn init_registry() -> cargo_test_support::registry::TestRegistry {
+    cargo_test_support::registry::init()
 }
 
 pub fn git_from(template: impl AsRef<std::path::Path>) -> cargo_test_support::Project {

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -66,17 +66,7 @@ fn unpublished_workspace_dependency() {
         .stdout_eq(str![])
         .stderr_eq(str![[r#"
 warning: disabled by user, skipping dependency v0.1.0 despite being unpublished
-warning: push target `origin/master` doesn't exist
-  Publishing application
-note: found `dummy-registry` as only allowed registry. Publishing to it automatically.
-    Updating `dummy-registry` index
-   Packaging application v0.1.0 ([ROOT]/foo/application)
-error: failed to prepare local package for uploading
-
-Caused by:
-  no matching package named `dependency` found
-  location searched: `dummy-registry` index (which is replacing registry `crates-io`)
-  required by package `application v0.1.0 ([ROOT]/foo/application)`
+error: application 0.1.0 depends on unpublished workspace package dependency 0.1.0
 
 "#]]);
 }
@@ -164,17 +154,7 @@ fn unpublished_git_dependency() {
         .failure()
         .stdout_eq(str![])
         .stderr_eq(str![[r#"
-warning: push target `origin/master` doesn't exist
-  Publishing application
-note: found `dummy-registry` as only allowed registry. Publishing to it automatically.
-    Updating `dummy-registry` index
-   Packaging application v0.1.0 ([ROOT]/foo)
-error: failed to prepare local package for uploading
-
-Caused by:
-  no matching package named `dependency` found
-  location searched: `dummy-registry` index (which is replacing registry `crates-io`)
-  required by package `application v0.1.0 ([ROOT]/foo)`
+error: application 0.1.0 depends on unpublished package dependency ^0.1.0
 
 "#]]);
 }

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1,0 +1,180 @@
+use cargo_test_support::cargo_test;
+use cargo_test_support::project;
+use snapbox::str;
+
+use crate::CargoCommand;
+use crate::create_default_gitconfig;
+use crate::init_registry;
+
+#[cargo_test]
+fn unpublished_workspace_dependency() {
+    let registry = init_registry();
+    create_default_gitconfig();
+    let project = project()
+        .file(".gitignore", "/target\n")
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            resolver = "2"
+            members = ["dependency", "application"]
+            "#,
+        )
+        .file(
+            "dependency/Cargo.toml",
+            r#"
+            [package]
+            name = "dependency"
+            version = "0.1.0"
+            edition = "2024"
+            description = "An unpublished dependency"
+            license = "MIT"
+            repository = "https://example.com"
+            "#,
+        )
+        .file("dependency/src/lib.rs", "pub fn dependency() {}")
+        .file(
+            "application/Cargo.toml",
+            r#"
+            [package]
+            name = "application"
+            version = "0.1.0"
+            edition = "2024"
+            publish = ["dummy-registry"]
+            description = "An application"
+            license = "MIT"
+            repository = "https://example.com"
+
+            [dependencies]
+            dependency = { path = "../dependency", version = "0.1.0" }
+            "#,
+        )
+        .file("application/src/lib.rs", "pub fn application() {}")
+        .build();
+    project.process("cargo").arg("generate-lockfile").run();
+    let repo = cargo_test_support::git::init(&project.root());
+    cargo_test_support::git::add(&repo);
+    cargo_test_support::git::commit(&repo);
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("release")
+        .args(["--package", "application", "--execute", "--no-confirm"])
+        .current_dir(project.root())
+        .env("CARGO_REGISTRIES_DUMMY_REGISTRY_TOKEN", registry.token())
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+warning: disabled by user, skipping dependency v0.1.0 despite being unpublished
+warning: push target `origin/master` doesn't exist
+  Publishing application
+note: found `dummy-registry` as only allowed registry. Publishing to it automatically.
+    Updating `dummy-registry` index
+   Packaging application v0.1.0 ([ROOT]/foo/application)
+error: failed to prepare local package for uploading
+
+Caused by:
+  no matching package named `dependency` found
+  location searched: `dummy-registry` index (which is replacing registry `crates-io`)
+  required by package `application v0.1.0 ([ROOT]/foo/application)`
+
+"#]]);
+}
+
+#[cargo_test]
+fn unpublished_git_dependency() {
+    let registry = init_registry();
+    create_default_gitconfig();
+    let dependency = cargo_test_support::git::new("dependency", |project| {
+        project
+            .file(
+                "Cargo.toml",
+                r#"
+                [package]
+                name = "dependency"
+                version = "0.1.0"
+                edition = "2024"
+                "#,
+            )
+            .file("src/lib.rs", "pub fn dependency() {}")
+    });
+    let git_dev_dependency = cargo_test_support::git::new("git-dev-dependency", |project| {
+        project
+            .file(
+                "Cargo.toml",
+                r#"
+                    [package]
+                    name = "git-dev-dependency"
+                    version = "0.1.0"
+                    edition = "2024"
+                    "#,
+            )
+            .file("src/lib.rs", "pub fn git_dev_dependency() {}")
+    });
+    let manifest = format!(
+        r#"
+        [package]
+        name = "application"
+        version = "0.1.0"
+        edition = "2024"
+        publish = ["dummy-registry"]
+        description = "An application"
+        license = "MIT"
+        repository = "https://example.com"
+
+        [dependencies]
+        dependency = {{ git = "{dependency_url}", version = "0.1.0" }}
+
+        [dev-dependencies]
+        git-dev-dependency = {{ git = "{git_dev_dependency_url}" }}
+        path-dev-dependency = {{ path = "path-dev-dependency" }}
+        "#,
+        dependency_url = dependency.url(),
+        git_dev_dependency_url = git_dev_dependency.url(),
+    );
+    let project = project()
+        .file(".gitignore", "/target\n")
+        .file("Cargo.toml", &manifest)
+        .file(
+            "path-dev-dependency/Cargo.toml",
+            r#"
+            [package]
+            name = "path-dev-dependency"
+            version = "0.1.0"
+            edition = "2024"
+            "#,
+        )
+        .file(
+            "path-dev-dependency/src/lib.rs",
+            "pub fn path_dev_dependency() {}",
+        )
+        .file("src/lib.rs", "pub fn application() {}")
+        .build();
+    project.process("cargo").arg("generate-lockfile").run();
+    let repo = cargo_test_support::git::init(&project.root());
+    cargo_test_support::git::add(&repo);
+    cargo_test_support::git::commit(&repo);
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("release")
+        .args(["--package", "application", "--execute", "--no-confirm"])
+        .current_dir(project.root())
+        .env("CARGO_REGISTRIES_DUMMY_REGISTRY_TOKEN", registry.token())
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+warning: push target `origin/master` doesn't exist
+  Publishing application
+note: found `dummy-registry` as only allowed registry. Publishing to it automatically.
+    Updating `dummy-registry` index
+   Packaging application v0.1.0 ([ROOT]/foo)
+error: failed to prepare local package for uploading
+
+Caused by:
+  no matching package named `dependency` found
+  location searched: `dummy-registry` index (which is replacing registry `crates-io`)
+  required by package `application v0.1.0 ([ROOT]/foo)`
+
+"#]]);
+}


### PR DESCRIPTION
Checks registry dependencies before publishing and returns an error when the required version is not available. This prevents a release from failing later after other steps have already run.

The check accounts for versions planned in the same release and includes regression coverage for published, unpublished, path-only, git, optional, dev, and workspace dependencies. The full workspace test suite passes locally.

Fixes #624